### PR TITLE
add support for Ganymed-ssh2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </parent>
 
   <artifactId>ssh-credentials</artifactId>
-  <version>1.6-SNAPSHOT</version>
+  <version>1.5.1</version>
   <packaging>hpi</packaging>
 
   <name>SSH Credentials Plugin</name>
@@ -61,7 +61,7 @@
     <connection>scm:git:git://github.com/jenkinsci/ssh-credentials-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/ssh-credentials-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/ssh-credentials-plugin</url>
-    <tag>HEAD</tag>
+    <tag>ssh-credentials-1.5.1</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </parent>
 
   <artifactId>ssh-credentials</artifactId>
-  <version>1.5</version>
+  <version>1.6-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>SSH Credentials Plugin</name>
@@ -61,7 +61,7 @@
     <connection>scm:git:git://github.com/jenkinsci/ssh-credentials-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/ssh-credentials-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/ssh-credentials-plugin</url>
-    <tag>ssh-credentials-1.5</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </parent>
 
   <artifactId>ssh-credentials</artifactId>
-  <version>1.5-SNAPSHOT</version>
+  <version>1.5</version>
   <packaging>hpi</packaging>
 
   <name>SSH Credentials Plugin</name>
@@ -61,7 +61,7 @@
     <connection>scm:git:git://github.com/jenkinsci/ssh-credentials-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/ssh-credentials-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/ssh-credentials-plugin</url>
-    <tag>HEAD</tag>
+    <tag>ssh-credentials-1.5</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,13 @@
       <version>0.1.42</version>
       <optional>true</optional>
     </dependency>
+
+    <dependency>
+      <groupId>ch.ethz.ganymed</groupId>
+      <artifactId>ganymed-ssh2</artifactId>
+      <version>261</version>
+    </dependency>
+      
     <!-- plugin dependencies -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>1.7.6</version>
+      <version>1.8.3</version>
     </dependency>
     <!-- jenkins dependencies -->
     <!-- test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </parent>
 
   <artifactId>ssh-credentials</artifactId>
-  <version>1.5.1</version>
+  <version>1.6-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>SSH Credentials Plugin</name>
@@ -61,7 +61,7 @@
     <connection>scm:git:git://github.com/jenkinsci/ssh-credentials-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/ssh-credentials-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/ssh-credentials-plugin</url>
-    <tag>ssh-credentials-1.5.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey.java
@@ -326,6 +326,17 @@ public class BasicSSHUserPrivateKey extends BaseSSHUser implements SSHUserPrivat
             return privateKeyFile;
         }
 
+        private Object readResolve() {
+            if (privateKeyFile != null
+                    && privateKeyFile.startsWith("---")
+                    && privateKeyFile.contains("---BEGIN")
+                    && privateKeyFile.contains("---END")) {
+                // this is a borked upgrade, not actually the file name but is actually the key contents
+                return new DirectEntryPrivateKeySource(privateKeyFile);
+            }
+            return this;
+        }
+
         @Override
         public long getPrivateKeysLastModified() {
             if (nextCheckLastModified > System.currentTimeMillis() || lastModified < 0) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey.java
@@ -250,6 +250,16 @@ public class BasicSSHUserPrivateKey extends BaseSSHUser implements SSHUserPrivat
         }
 
         /**
+         * Returns the private key.
+         *
+         * @return the private key.
+         */
+        @SuppressWarnings("unused") // used by Jelly EL
+        public String getPrivateKey() {
+            return privateKey;
+        }
+
+        /**
          * {@inheritDoc}
          */
         @Extension

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/GanymedSSHPasswordAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/GanymedSSHPasswordAuthenticator.java
@@ -1,0 +1,172 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011-2012, CloudBees, Inc., Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.sshcredentials.impl;
+
+import ch.ethz.ssh2.Connection;
+import ch.ethz.ssh2.InteractiveCallback;
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator;
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticatorFactory;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.logging.Logger;
+
+/**
+ * Does password auth with a {@link com.trilead.ssh2.Connection}.
+ */
+public class GanymedSSHPasswordAuthenticator extends SSHAuthenticator<Connection, StandardUsernamePasswordCredentials> {
+
+    /**
+     * Our logger
+     */
+    private static final Logger LOGGER = Logger.getLogger(GanymedSSHPasswordAuthenticator.class.getName());
+
+    /**
+     * Constructor.
+     *
+     * @param connection the connection we will be authenticating.
+     */
+    public GanymedSSHPasswordAuthenticator(Connection connection, StandardUsernamePasswordCredentials user) {
+        super(connection, user);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean canAuthenticate() {
+        try {
+            for (String authMethod : getConnection().getRemainingAuthMethods(getUser().getUsername())) {
+                if ("password".equals(authMethod)) {
+                    // prefer password
+                    return true;
+                }
+                if ("keyboard-interactive".equals(authMethod)) {
+                    return true;
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace(getListener().error("Failed to authenticate"));
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected boolean doAuthenticate() {
+        final StandardUsernamePasswordCredentials user = getUser();
+        final String username = user.getUsername();
+
+        try {
+            final Connection connection = getConnection();
+            final String password = user.getPassword().getPlainText();
+            boolean tried = false;
+
+            List<String> availableMethods = Arrays.asList(connection.getRemainingAuthMethods(username));
+            if (availableMethods.contains("password")) {
+                // prefer password
+                if (connection.authenticateWithPassword(username, password)) {
+                    LOGGER.fine("Authentication with 'password' succeeded.");
+                    return true;
+                }
+                getListener().error("Failed to authenticate as %s. Wrong password. (credentialId:%s/method:password)",
+                        username, user.getId());
+                tried = true;
+            }
+            if (availableMethods.contains("keyboard-interactive")) {
+                if (connection.authenticateWithKeyboardInteractive(username, new InteractiveCallback() {
+                    public String[] replyToChallenge(String name, String instruction, int numPrompts,
+                                                     String[] prompt, boolean[] echo)
+                            throws Exception {
+                        // most SSH servers just use keyboard interactive to prompt for the password
+                        // match "assword" is safer than "password"... you don't *want* to know why!
+                        return prompt != null && prompt.length > 0 && prompt[0].toLowerCase(Locale.ENGLISH)
+                                .contains("assword")
+                                ? new String[]{password}
+                                : new String[0];
+                    }
+                })) {
+                    LOGGER.fine("Authentication with  'keyboard-interactive' succeeded.");
+                    return true;
+                }
+                getListener()
+                        .error("Failed to authenticate as %s. Wrong password. "
+                                + "(credentialId:%s/method:keyboard-interactive)",
+                                username, user.getId());
+                tried = true;
+            }
+
+            if (!tried) {
+                getListener().error("The server does not allow password authentication. Available options are %s",
+                        availableMethods);
+            }
+        } catch (IOException e) {
+            e.printStackTrace(getListener()
+                    .error("Unexpected error while trying to authenticate as %s with credential=%s", username,
+                            user.getId()));
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Extension
+    public static class Factory extends SSHAuthenticatorFactory {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        @SuppressWarnings("unchecked")
+        protected <C, U extends StandardUsernameCredentials> SSHAuthenticator<C, U> newInstance(@NonNull C connection,
+                                                                                                @NonNull U user) {
+            if (supports(connection.getClass(), user.getClass())) {
+                return (SSHAuthenticator<C, U>) new GanymedSSHPasswordAuthenticator((Connection) connection,
+                        (StandardUsernamePasswordCredentials) user);
+            }
+            return null;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        protected <C, U extends StandardUsernameCredentials> boolean supports(@NonNull Class<C> connectionClass,
+                                                                              @NonNull Class<U> userClass) {
+            return Connection.class.isAssignableFrom(connectionClass)
+                    && StandardUsernamePasswordCredentials.class.isAssignableFrom(userClass);
+        }
+
+        private static final long serialVersionUID = 1L;
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/GanymedSSHPublicKeyAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/GanymedSSHPublicKeyAuthenticator.java
@@ -1,0 +1,147 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011-2012, CloudBees, Inc., Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.sshcredentials.impl;
+
+import ch.ethz.ssh2.Connection;
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator;
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticatorFactory;
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.util.Secret;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * Does public key auth with a {@link com.trilead.ssh2.Connection}.
+ */
+public class GanymedSSHPublicKeyAuthenticator extends SSHAuthenticator<Connection, SSHUserPrivateKey> {
+
+    /**
+     * Our logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(GanymedSSHPublicKeyAuthenticator.class.getName());
+
+    /**
+     * Constructor.
+     *
+     * @param connection the connection we will be authenticating.
+     */
+    public GanymedSSHPublicKeyAuthenticator(Connection connection, SSHUserPrivateKey user) {
+        super(connection, user);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean canAuthenticate() {
+        try {
+            return getRemainingAuthMethods().contains("publickey");
+        } catch (IOException e) {
+            e.printStackTrace(getListener().error("Failed to authenticate"));
+            return false;
+        }
+    }
+
+    private List<String> getRemainingAuthMethods() throws IOException {
+        return Arrays.asList(getConnection().getRemainingAuthMethods(getUser().getUsername()));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected boolean doAuthenticate() {
+        final SSHUserPrivateKey user = getUser();
+        final String username = user.getUsername();
+        try {
+            final Connection connection = getConnection();
+            final Secret userPassphrase = user.getPassphrase();
+            final String passphrase = userPassphrase == null ? null : userPassphrase.getPlainText();
+
+            Collection<String> availableMethods = getRemainingAuthMethods();
+            if (availableMethods.contains("publickey")) {
+                int count = 0;
+                for (String privateKey : getPrivateKeys(user)) {
+                    if (connection.authenticateWithPublicKey(username, privateKey.toCharArray(), passphrase)) {
+                        LOGGER.fine("Authentication with 'publickey' succeeded.");
+                        return true;
+                    }
+                    count++;
+                    getListener()
+                            .error("Server rejected the %d private key(s) for %s (credentialId:%s/method:publickey)",
+                                    count, username, user.getId());
+                }
+                return false;
+            } else {
+                getListener().error("The server does not allow public key authentication. Available options are %s",
+                        availableMethods);
+                return false;
+            }
+        } catch (IOException e) {
+            e.printStackTrace(getListener()
+                    .error("Failed to authenticate as %s with credential=%s", username, getUser().getId()));
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Extension
+    public static class Factory extends SSHAuthenticatorFactory {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        @SuppressWarnings("unchecked")
+        protected <C, U extends StandardUsernameCredentials> SSHAuthenticator<C, U> newInstance(@NonNull C connection,
+                                                                                                @NonNull U user) {
+            if (supports(connection.getClass(), user.getClass())) {
+                return (SSHAuthenticator<C, U>) new GanymedSSHPublicKeyAuthenticator((Connection) connection,
+                        (SSHUserPrivateKey) user);
+            }
+            return null;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        protected <C, U extends StandardUsernameCredentials> boolean supports(@NonNull Class<C> connectionClass,
+                                                                              @NonNull Class<U> userClass) {
+            return Connection.class.isAssignableFrom(connectionClass)
+                    && SSHUserPrivateKey.class.isAssignableFrom(userClass);
+        }
+
+        private static final long serialVersionUID = 1L;
+    }
+}

--- a/src/main/resources/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey/credentials.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey/credentials.jelly
@@ -23,7 +23,7 @@
  ~ THE SOFTWARE.
  -->
 
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
   <f:invisibleEntry>
     <f:textbox field="id"/>
   </f:invisibleEntry>
@@ -37,7 +37,25 @@
     <f:textbox/>
   </f:entry>
   <f:entry title="${%Private Key}" field="privateKeySource">
-    <f:hetero-radio descriptors="${descriptor.privateKeySources}"/>
+    <!-- TODO switch back to hetero-radio when the initial expansion bug is fixed -->
+    <j:scope>
+      <table style="width:100%">
+        <j:set var="currentInstance" value="${instance.privateKeySource}" />
+        <j:set var="currentDescriptor" value="${currentInstance.descriptor}" />
+        <j:set var="currentName" value="${h.generateId()}.privateKeySource" />
+        <j:forEach var="d" items="${descriptor.privateKeySources}" varStatus="loop">
+          <f:radioBlock name="${currentName}" help="${d.helpFile}" value="${loop.index}"
+            title="${d.displayName}" checked="${currentDescriptor==d}">
+            <j:set var="descriptor" value="${d}" />
+            <j:set var="instance" value="${currentDescriptor==d?currentInstance:null}" />
+            <st:include from="${d}" page="${d.configPage}" optional="true" />
+            <f:invisibleEntry>
+              <input type="hidden" name="stapler-class" value="${d.clazz.name}" />
+            </f:invisibleEntry>
+          </f:radioBlock>
+        </j:forEach>
+      </table>
+    </j:scope>
   </f:entry>
   <f:advanced>
     <f:entry title="${%Passphrase}" field="passphrase">


### PR DESCRIPTION
[Ganymed-ssh2](https://code.google.com/p/ganymed-ssh-2/) is _maintained_ version of original [Ganymed ssh client](http://www.ganymed.ethz.ch/ssh2/) forked by trilead as trilead-ssh2.
