### PR TITLE
JENKINS-23511: Add serialVersionUID to anonymous inner class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </parent>
 
   <artifactId>ssh-credentials</artifactId>
-  <version>1.10-SNAPSHOT</version>
+  <version>1.10</version>
   <packaging>hpi</packaging>
 
   <name>SSH Credentials Plugin</name>
@@ -61,7 +61,7 @@
     <connection>scm:git:git://github.com/jenkinsci/ssh-credentials-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/ssh-credentials-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/ssh-credentials-plugin</url>
-    <tag>HEAD</tag>
+    <tag>ssh-credentials-1.10</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </parent>
 
   <artifactId>ssh-credentials</artifactId>
-  <version>1.10</version>
+  <version>1.11-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>SSH Credentials Plugin</name>
@@ -61,7 +61,7 @@
     <connection>scm:git:git://github.com/jenkinsci/ssh-credentials-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/ssh-credentials-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/ssh-credentials-plugin</url>
-    <tag>ssh-credentials-1.10</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHAuthenticator.java
@@ -195,6 +195,7 @@ public abstract class SSHAuthenticator<C, U extends StandardUsernameCredentials>
         } else {
             // if running on the slave, bring these factories over here
             factories = Channel.current().call(new Callable<Collection<SSHAuthenticatorFactory>, IOException>() {
+                private static final long serialVersionUID = 1;
                 public Collection<SSHAuthenticatorFactory> call() throws IOException {
                     return new ArrayList<SSHAuthenticatorFactory>(
                             Jenkins.getInstance().getExtensionList(SSHAuthenticatorFactory.class));

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHAuthenticatorException.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHAuthenticatorException.java
@@ -1,7 +1,5 @@
 package com.cloudbees.jenkins.plugins.sshcredentials;
 
-import com.jcraft.jsch.JSchException;
-
 /**
  * @author stephenc
  * @since 25/10/2012 15:20

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHUserListBoxModel.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHUserListBoxModel.java
@@ -4,14 +4,11 @@ import com.cloudbees.plugins.credentials.CredentialsMatcher;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.AbstractIdCredentialsListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Util;
-import hudson.model.Descriptor;
-import hudson.model.Item;
-import hudson.model.Job;
 import hudson.security.ACL;
-import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 
 import java.util.Arrays;
@@ -19,71 +16,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import static com.cloudbees.plugins.credentials.CredentialsMatchers.filter;
-
-/**
- * {@link ListBoxModel} with {@link StandardUsernameCredentials} support.
- * <p/>
- * This class is convenient for providing the config.groovy/.jelly fragment for a collection of {@link StandardUsernameCredentials} objects.
- * <p/>
- * If you want to let the user configure an {@link StandardUsernameCredentials} object, do the following:
- * <p/>
- * First, create a field that stores the credential ID and defines a corresponding parameter in the constructor:
- * <p/>
- * <pre>
- * private String credentialId;
- *
- * &#64;DataBoundConstructor
- * public MyModel( .... , String credentialId) {
- *     this.credentialId = credentialId;
- *     ...
- * }
- * </pre>
- * <p/>
- * Your <tt>config.groovy</tt> should have the following entry to render a drop-down list box:
- * <p/>
- * <pre>
- * f.entry(title:_("Credentials"), field:"credentialId") {
- *     f.select()
- * }
- * </pre>
- * <p/>
- * Finally, your {@link Descriptor} implementation should have the <tt>doFillCredentialsIdItems</tt> method, which
- * lists up the credentials available in this context:
- * <p/>
- * <pre>
- * public SSHUserListBoxModel doFillCredentialsIdItems() {
- *     return new SSHUserListBoxModel()
- *             .addCollection(CredentialsProvider.lookupCredentials(SSHUser.class,...));
- * }
- * </pre>
- * <p/>
- * <p/>
- * Exactly which overloaded version of the {@link CredentialsProvider#lookupCredentials(Class)} depends on
- * the context in which your model operates. Here are a few common examples:
- * <p/>
- * <dl>
- * <dt>System-level settings
- * <dd>
- * If your model is a singleton in the whole Jenkins instance, things that belong to the root {@link Jenkins}
- * (such as slaves), or do not have any ancestors serving as the context, then use {@link #addSystemScopeCredentials()}.
- * <p/>
- * <dt>Job-level settings
- * <dd>
- * If your model is a configuration fragment added to a {@link Item} (such as its major subtype {@link Job}),
- * then use that {@link Item} as the context and call {@link CredentialsProvider#lookupCredentials(Class, Item)}
- * See below:
- * <p/>
- * <pre>
- * public SSHUserListBoxModel doFillCredentialsIdItems(@AncestorInPath AbstractProject context) {
- *     return new SSHUserListBoxModel().addCollection(
- *         CredentialsProvider.lookupCredentials(StandardUsernameCredentials.class, context, auth, domainRequirements)));
- * }
- * </pre>
- * </dl>
- *
- * @author Kohsuke Kawaguchi
- */
+/** @deprecated Use {@link StandardUsernameListBoxModel} with {@link SSHAuthenticator} instead. */
 public class SSHUserListBoxModel extends AbstractIdCredentialsListBoxModel<SSHUserListBoxModel,StandardUsernameCredentials> {
     /**
      * {@inheritDoc}

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKeyTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKeyTest.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014 Jesse Glick.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.jenkins.plugins.sshcredentials.impl;
+
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import hudson.FilePath;
+import hudson.remoting.Callable;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class BasicSSHUserPrivateKeyTest {
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Test public void masterKeysOnSlave() throws Exception {
+        FilePath keyfile = r.jenkins.getRootPath().child("key");
+        keyfile.write("stuff", null);
+        SSHUserPrivateKey key = new BasicSSHUserPrivateKey(CredentialsScope.SYSTEM, "mycreds", "git", new BasicSSHUserPrivateKey.FileOnMasterPrivateKeySource(keyfile.getRemote()), null, null);
+        assertEquals("[stuff]", key.getPrivateKeys().toString());
+        // TODO would be more interesting to use a Docker fixture to demonstrate that the file load is happening only from the master side
+        assertEquals("[stuff]", r.createOnlineSlave().getChannel().call(new LoadPrivateKeys(key)));
+    }
+    private static class LoadPrivateKeys implements Callable<String,Exception> {
+        private final SSHUserPrivateKey key;
+        LoadPrivateKeys(SSHUserPrivateKey key) {
+            this.key = key;
+        }
+        @Override public String call() throws Exception {
+            return key.getPrivateKeys().toString();
+        }
+    }
+
+    // TODO demonstrate that all private key sources are round-tripped in XStream
+
+}


### PR DESCRIPTION
When doing RMI with VMs from multiple vendors, all class should have a serialVersionUID
as the default value generated by different VMs may not always match.

I've tested this using in the Jenkins ver. 1.532.3 LTS server and this corrects the linked issue for me when building on an AIX slave (IBM JVM).