### PR TITLE
Redeclare JSch dependency to the jsch-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,18 +85,17 @@
   </pluginRepositories>
 
   <dependencies>
-    <!-- regular dependencies -->
-    <dependency>
-      <groupId>com.jcraft</groupId>
-      <artifactId>jsch</artifactId>
-      <version>0.1.42</version>
-      <optional>true</optional>
-    </dependency>
     <!-- plugin dependencies -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
       <version>1.16.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jsch</artifactId>
+      <version>0.1.42</version>
+      <optional>true</optional>
     </dependency>
     <!-- jenkins dependencies -->
     <!-- test dependencies -->


### PR DESCRIPTION
So I've created the ssh-plugin and forked it under the jenkinsci/jsch-plugin, this changes the JSch dependency to that plugin. I need this for the ssh-credentials support in ssh-plugin.