### PR TITLE
[JENKINS-25412] Update JSch from 0.1.42 to 0.1.49

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>com.jcraft</groupId>
       <artifactId>jsch</artifactId>
-      <version>0.1.42</version>
+      <version>0.1.49</version>
       <optional>true</optional>
     </dependency>
     <!-- plugin dependencies -->


### PR DESCRIPTION
When recent ssh algorithm are used and not supported by JSch yet, the
Jenkins slaves can not be connected to over ssh.  Bump JSch version to
0.1.49 to provide some additional algorithms.

Upstream Changelog
http://www.jcraft.com/jsch/ChangeLog