### PR TITLE
[JENKINS-34336] Upgrade to parent pom 2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.532.2</version>
+    <version>2.6</version>
   </parent>
 
   <artifactId>ssh-credentials</artifactId>
@@ -65,11 +65,8 @@
   </scm>
 
   <properties>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.findbugs.version>3.0.1</maven.findbugs.version>
-    <maven.findbugs.failure.strict>true</maven.findbugs.failure.strict>
+    <jenkins.version>1.580.1</jenkins.version>
+    <java.level>6</java.level>
   </properties>
 
   <repositories>
@@ -102,99 +99,11 @@
     <!-- jenkins dependencies -->
     <!-- test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-core</artifactId>
       <version>0.12.0</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.6.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-      <version>1.6.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-      <version>3.0.0</version>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <version>1.3.1</version>
-          <executions>
-            <execution>
-              <id>enforce-maven</id>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
-              <configuration>
-                <rules>
-                  <requireMavenVersion>
-                    <version>(,2.1.0),(2.1.0,2.2.0),(2.2.0,)</version>
-                    <message>Maven 2.1.0 and 2.2.0 produce incorrect GPG signatures and checksums respectively.</message>
-                  </requireMavenVersion>
-                  <requireMavenVersion>
-                    <version>(,3.0),[3.0.4,)</version>
-                    <message>Maven 3.0 through 3.0.3 inclusive do not pass correct settings.xml to Maven Release Plugin.</message>
-                  </requireMavenVersion>
-                </rules>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-    <plugins>
-      <plugin>
-        <groupId>org.jenkins-ci.tools</groupId>
-        <artifactId>maven-hpi-plugin</artifactId>
-        <configuration>
-          <compatibleSinceVersion>1.0</compatibleSinceVersion>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5</version>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>${maven.findbugs.version}</version>
-        <configuration>
-          <xmlOutput>true</xmlOutput>
-          <findbugsXmlWithMessages>true</findbugsXmlWithMessages>
-          <excludeFilterFile>src/findbugs/excludesFilter.xml</excludeFilterFile>
-          <failOnError>${maven.findbugs.failure.strict}</failOnError>
-        </configuration>
-        <executions>
-          <execution>
-            <id>run-findbugs</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHAuthenticator.java
@@ -30,13 +30,14 @@ import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.BuildListener;
 import hudson.model.Hudson;
 import hudson.model.TaskListener;
-import hudson.remoting.Callable;
 import hudson.remoting.Channel;
 import hudson.util.StreamTaskListener;
 import jenkins.model.Jenkins;
+import jenkins.security.MasterToSlaveCallable;
 import net.jcip.annotations.GuardedBy;
 
 import java.io.IOException;
@@ -180,6 +181,7 @@ public abstract class SSHAuthenticator<C, U extends StandardUsernameCredentials>
      * @return a {@link SSHAuthenticator} that may or may not be able to successfully authenticate.
      * @since 1.4
      */
+    @SuppressFBWarnings(value="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification="https://github.com/jenkinsci/jenkins/pull/2094")
     @NonNull
     public static <C, U extends StandardUsernameCredentials> SSHAuthenticator<C, U> newInstance(@NonNull C connection,
                                                                                                 @NonNull U user,
@@ -194,7 +196,8 @@ public abstract class SSHAuthenticator<C, U extends StandardUsernameCredentials>
             factories = Jenkins.getInstance().getExtensionList(SSHAuthenticatorFactory.class);
         } else {
             // if running on the slave, bring these factories over here
-            factories = Channel.current().call(new Callable<Collection<SSHAuthenticatorFactory>, IOException>() {
+            factories = Channel.current().call(new MasterToSlaveCallable<Collection<SSHAuthenticatorFactory>, IOException>() {
+                @SuppressFBWarnings(value="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification="https://github.com/jenkinsci/jenkins/pull/2094")
                 public Collection<SSHAuthenticatorFactory> call() throws IOException {
                     return new ArrayList<SSHAuthenticatorFactory>(
                             Jenkins.getInstance().getExtensionList(SSHAuthenticatorFactory.class));

--- a/src/main/resources/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey/DirectEntryPrivateKeySource/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey/DirectEntryPrivateKeySource/config.jelly
@@ -23,6 +23,7 @@
  ~ THE SOFTWARE.
  -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:entry title="${%Key}" field="privateKey">
     <f:textarea/>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey/FileOnMasterPrivateKeySource/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey/FileOnMasterPrivateKeySource/config.jelly
@@ -23,6 +23,7 @@
  ~ THE SOFTWARE.
  -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:entry title="${%File}" field="privateKeyFile">
     <f:textbox/>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey/credentials.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey/credentials.jelly
@@ -23,6 +23,7 @@
  ~ THE SOFTWARE.
  -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
   <f:entry title="${%Username}" field="username">
     <f:textbox/>

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKeyTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKeyTest.java
@@ -33,6 +33,8 @@ import hudson.FilePath;
 import hudson.model.Hudson;
 import hudson.remoting.Callable;
 import hudson.security.ACL;
+import jenkins.security.MasterToSlaveCallable;
+
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.Rule;
@@ -56,7 +58,7 @@ public class BasicSSHUserPrivateKeyTest {
         // TODO would be more interesting to use a Docker fixture to demonstrate that the file load is happening only from the master side
         assertEquals("[stuff]", r.createOnlineSlave().getChannel().call(new LoadPrivateKeys(key)));
     }
-    private static class LoadPrivateKeys implements Callable<String,Exception> {
+    private static class LoadPrivateKeys extends MasterToSlaveCallable<String,Exception> {
         private final SSHUserPrivateKey key;
         LoadPrivateKeys(SSHUserPrivateKey key) {
             this.key = key;

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/JSchSSHPasswordAuthenticatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/JSchSSHPasswordAuthenticatorTest.java
@@ -24,9 +24,7 @@
 package com.cloudbees.jenkins.plugins.sshcredentials.impl;
 
 import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator;
-import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPassword;
 import com.cloudbees.plugins.credentials.CredentialsScope;
-import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.jcraft.jsch.HostKey;
 import com.jcraft.jsch.HostKeyRepository;
@@ -40,10 +38,13 @@ import org.apache.sshd.server.UserAuth;
 import org.apache.sshd.server.auth.UserAuthPassword;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.session.ServerSession;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.Arrays;
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -51,18 +52,19 @@ import java.util.logging.Logger;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
-public class JSchSSHPasswordAuthenticatorTest extends HudsonTestCase {
+public class JSchSSHPasswordAuthenticatorTest {
 
     private JSchConnector connector;
     private StandardUsernamePasswordCredentials user;
 
-    @Override
-    protected void tearDown() throws Exception {
+    @Rule public JenkinsRule r = new JenkinsRule();
+    
+    @After
+    public void tearDown() throws Exception {
         if (connector != null) {
             connector.close();
             connector = null;
         }
-        super.tearDown();
     }
 
     // disabled as Apache MINA sshd does not provide easy mech for giving a Keyboard Interactive authenticator
@@ -87,11 +89,12 @@ public class JSchSSHPasswordAuthenticatorTest extends HudsonTestCase {
         assertThat(connector.getSession().isConnected(), is(true));
     }
 
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         user =(StandardUsernamePasswordCredentials) Items.XSTREAM.fromXML(Items.XSTREAM.toXML(new BasicSSHUserPassword(CredentialsScope.SYSTEM, null, "foobar", "foomanchu", null)));
     }
 
+    @Test
     public void testPassword() throws Exception {
         SshServer sshd = SshServer.setUpDefaultServer();
         sshd.setPort(0);
@@ -123,6 +126,7 @@ public class JSchSSHPasswordAuthenticatorTest extends HudsonTestCase {
         }
     }
 
+    @Test
     public void testFactory() throws Exception {
         SshServer sshd = SshServer.setUpDefaultServer();
         sshd.setPort(0);

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/JSchSSHPublicKeyAuthenticatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/JSchSSHPublicKeyAuthenticatorTest.java
@@ -27,8 +27,6 @@ import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator;
 import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
 import com.cloudbees.plugins.credentials.CredentialsDescriptor;
 import com.cloudbees.plugins.credentials.CredentialsScope;
-import com.trilead.ssh2.Connection;
-import com.trilead.ssh2.ServerHostKeyVerifier;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.util.Secret;
@@ -39,7 +37,11 @@ import org.apache.sshd.server.UserAuth;
 import org.apache.sshd.server.auth.UserAuthPublicKey;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.session.ServerSession;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.security.PublicKey;
 import java.util.Arrays;
@@ -52,22 +54,23 @@ import java.util.logging.Logger;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
-public class JSchSSHPublicKeyAuthenticatorTest extends HudsonTestCase {
+public class JSchSSHPublicKeyAuthenticatorTest {
 
     private JSchConnector connector;
     private SSHUserPrivateKey user;
 
-    @Override
-    protected void tearDown() throws Exception {
+    @Rule public JenkinsRule r = new JenkinsRule();
+    
+    @After
+    public void tearDown() throws Exception {
         if (connector != null) {
             connector.close();
             connector = null;
         }
-        super.tearDown();
     }
 
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         user = new SSHUserPrivateKey() {
 
             @NonNull
@@ -132,6 +135,7 @@ public class JSchSSHPublicKeyAuthenticatorTest extends HudsonTestCase {
         };
     }
 
+    @Test
     public void testAuthenticate() throws Exception {
         SshServer sshd = SshServer.setUpDefaultServer();
         sshd.setPort(0);
@@ -164,6 +168,7 @@ public class JSchSSHPublicKeyAuthenticatorTest extends HudsonTestCase {
         }
     }
 
+    @Test
     public void testFactory() throws Exception {
         SshServer sshd = SshServer.setUpDefaultServer();
         sshd.setPort(0);

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/TrileadSSHPasswordAuthenticatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/TrileadSSHPasswordAuthenticatorTest.java
@@ -41,7 +41,11 @@ import org.apache.sshd.server.UserAuth;
 import org.apache.sshd.server.auth.UserAuthPassword;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.session.ServerSession;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.Arrays;
 import java.util.logging.Level;
@@ -50,14 +54,16 @@ import java.util.logging.Logger;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public class TrileadSSHPasswordAuthenticatorTest extends HudsonTestCase {
+public class TrileadSSHPasswordAuthenticatorTest {
 
     private Connection connection;
     private StandardUsernamePasswordCredentials user;
     private SshServer sshd;
 
-    @Override
-    protected void tearDown() throws Exception {
+    @Rule public JenkinsRule r = new JenkinsRule();
+    
+    @After
+    public void tearDown() throws Exception {
         if (connection != null) {
             connection.close();
             connection = null;
@@ -69,7 +75,6 @@ public class TrileadSSHPasswordAuthenticatorTest extends HudsonTestCase {
                 Logger.getLogger(getClass().getName()).log(Level.WARNING, "Problems shutting down ssh server", t);
             }
         }
-        super.tearDown();
     }
 
     // disabled as Apache MINA sshd does not provide easy mech for giving a Keyboard Interactive authenticator
@@ -87,11 +92,12 @@ public class TrileadSSHPasswordAuthenticatorTest extends HudsonTestCase {
         assertThat(instance.isAuthenticated(), is(true));
     }
 
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         user =(StandardUsernamePasswordCredentials) Items.XSTREAM.fromXML(Items.XSTREAM.toXML(new BasicSSHUserPassword(CredentialsScope.SYSTEM, null, "foobar", "foomanchu", null)));
     }
 
+    @Test
     public void testPassword() throws Exception {
         sshd = createPasswordAuthenticatedSshServer();
         sshd.start();
@@ -122,6 +128,7 @@ public class TrileadSSHPasswordAuthenticatorTest extends HudsonTestCase {
         return sshd;
     }
 
+    @Test
     public void testFactory() throws Exception {
         sshd = createPasswordAuthenticatedSshServer();
         sshd.start();
@@ -134,6 +141,7 @@ public class TrileadSSHPasswordAuthenticatorTest extends HudsonTestCase {
         assertThat(instance.isAuthenticated(), is(true));
     }
 
+    @Test
     public void testFactoryAltUsername() throws Exception {
         sshd = createPasswordAuthenticatedSshServer("bill");
         sshd.start();
@@ -156,11 +164,12 @@ public class TrileadSSHPasswordAuthenticatorTest extends HudsonTestCase {
     /**
      * Brings the {@link SSHAuthenticatorFactory} to a slave.
      */
+    @Test
     public void testSlave() throws Exception {
         SshServer sshd = createPasswordAuthenticatedSshServer();
         sshd.start();
 
-        DumbSlave s = createSlave();
+        DumbSlave s = r.createSlave();
         Computer c = s.toComputer();
         c.connect(false).get();
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/TrileadSSHPasswordAuthenticatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/TrileadSSHPasswordAuthenticatorTest.java
@@ -25,16 +25,15 @@ package com.cloudbees.jenkins.plugins.sshcredentials.impl;
 
 import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator;
 import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticatorFactory;
-import com.cloudbees.jenkins.plugins.sshcredentials.SSHUser;
-import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPassword;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.trilead.ssh2.Connection;
 import com.trilead.ssh2.ServerHostKeyVerifier;
 import hudson.model.Computer;
 import hudson.model.Items;
-import hudson.remoting.Callable;
 import hudson.slaves.DumbSlave;
+import jenkins.security.MasterToSlaveCallable;
+
 import org.apache.sshd.SshServer;
 import org.apache.sshd.common.NamedFactory;
 import org.apache.sshd.server.PasswordAuthenticator;
@@ -177,7 +176,7 @@ public class TrileadSSHPasswordAuthenticatorTest extends HudsonTestCase {
         }
     }
 
-    private static final class RemoteConnectionTest implements Callable<Void, Exception> {
+    private static final class RemoteConnectionTest extends MasterToSlaveCallable<Void, Exception> {
         private final int port;
         private StandardUsernamePasswordCredentials user;
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/TrileadSSHPublicKeyAuthenticatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/TrileadSSHPublicKeyAuthenticatorTest.java
@@ -39,7 +39,11 @@ import org.apache.sshd.server.UserAuth;
 import org.apache.sshd.server.auth.UserAuthPublicKey;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.session.ServerSession;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.security.PublicKey;
 import java.util.Arrays;
@@ -51,22 +55,23 @@ import java.util.logging.Logger;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public class TrileadSSHPublicKeyAuthenticatorTest extends HudsonTestCase {
+public class TrileadSSHPublicKeyAuthenticatorTest {
 
     private Connection connection;
     private SSHUserPrivateKey user;
 
-    @Override
-    protected void tearDown() throws Exception {
+    @Rule public JenkinsRule r = new JenkinsRule();
+    
+    @After
+    public void tearDown() throws Exception {
         if (connection != null) {
             connection.close();
             connection = null;
         }
-        super.tearDown();
     }
 
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         user = new SSHUserPrivateKey() {
 
             @NonNull
@@ -130,6 +135,7 @@ public class TrileadSSHPublicKeyAuthenticatorTest extends HudsonTestCase {
         };
     }
 
+    @Test
     public void testAuthenticate() throws Exception {
         SshServer sshd = SshServer.setUpDefaultServer();
         sshd.setPort(0);
@@ -165,6 +171,7 @@ public class TrileadSSHPublicKeyAuthenticatorTest extends HudsonTestCase {
         }
     }
 
+    @Test
     public void testFactory() throws Exception {
         SshServer sshd = SshServer.setUpDefaultServer();
         sshd.setPort(0);
@@ -199,6 +206,7 @@ public class TrileadSSHPublicKeyAuthenticatorTest extends HudsonTestCase {
         }
     }
 
+    @Test
     public void testAltUsername() throws Exception {
         SshServer sshd = SshServer.setUpDefaultServer();
         sshd.setPort(0);


### PR DESCRIPTION
[JENKINS-34336](https://issues.jenkins-ci.org/browse/JENKINS-34336)

- [x] Upgrade to parent pom `2.6`
- [x] Upgrade baseline from `1.532.2` to `1.580.1` (SECURITY-144)
- [x] Use `MasterToSlaveCallable` where appropriate. (Please specifically review this)
- [x] Fix FindBugs errors
- [x] Fix test errors
- [x] Update tests to use `JenkinsRule`

@reviewbybees esp. @stephenc 