### PR TITLE
[FIXED JENKINS-35562] Upgrade to Credentials 2.1.0+ API for populating credentials drop-down

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>1.580.1</jenkins.version>
+    <jenkins.version>1.609</jenkins.version>
     <java.level>6</java.level>
   </properties>
 
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>1.25</version>
+      <version>2.1.0</version>
     </dependency>
     <!-- jenkins dependencies -->
     <!-- test dependencies -->

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHAuthenticator.java
@@ -261,7 +261,7 @@ public abstract class SSHAuthenticator<C, U extends StandardUsernameCredentials>
                                                                                  @NonNull Class<U> userClass) {
         connectionClass.getClass(); // throw NPE if null
         userClass.getClass(); // throw NPE if null
-        for (SSHAuthenticatorFactory factory : Hudson.getInstance().getExtensionList(SSHAuthenticatorFactory.class)) {
+        for (SSHAuthenticatorFactory factory : ExtensionList.lookup(SSHAuthenticatorFactory.class)) {
             if (factory.supports(connectionClass, userClass)) {
                 return true;
             }

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHUserListBoxModel.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHUserListBoxModel.java
@@ -144,9 +144,8 @@ public class SSHUserListBoxModel extends AbstractIdCredentialsListBoxModel<SSHUs
      */
     public SSHUserListBoxModel withSystemScopeCredentials(CredentialsMatcher matcher,
                                                           List<DomainRequirement> domainRequirements) {
-        withMatching(matcher,
-                CredentialsProvider.lookupCredentials(StandardUsernameCredentials.class, Jenkins.getInstance(),
-                        ACL.SYSTEM, domainRequirements));
+        includeMatchingAs(ACL.SYSTEM, Jenkins.getActiveInstance(), StandardUsernameCredentials.class,
+                domainRequirements, matcher);
         return this;
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey.java
@@ -36,6 +36,7 @@ import hudson.model.Hudson;
 import hudson.remoting.Channel;
 import hudson.util.Secret;
 import java.io.ObjectStreamException;
+import jenkins.model.Jenkins;
 import net.jcip.annotations.GuardedBy;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
@@ -199,7 +200,7 @@ public class BasicSSHUserPrivateKey extends BaseSSHUser implements SSHUserPrivat
         }
 
         public DescriptorExtensionList<PrivateKeySource, Descriptor<PrivateKeySource>> getPrivateKeySources() {
-            return Hudson.getInstance().getDescriptorList(PrivateKeySource.class);
+            return Jenkins.getActiveInstance().getDescriptorList(PrivateKeySource.class);
         }
 
         /**


### PR DESCRIPTION
This is a deprecated class, and should not be used, but it makes sense to have to use the newer API anyway

@reviewbybees