### PR TITLE
JENKINS-39836: InvalidClassException for SSHAuthenticator on many dif…

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHAuthenticator.java
@@ -326,10 +326,10 @@ public abstract class SSHAuthenticator<C, U extends StandardUsernameCredentials>
     private static class Matcher implements CredentialsMatcher {
         /**
          * Standardize serialization across different JVMs.
-	 *
-	 * @since 1.13
+         *
+         * @since 1.13
          */
-	// historical value generated from 1.12 code with Java 8
+        // historical value generated from 1.12 code with Java 8
 	private static final Long serialVersionUID = -5078593817273453864L; 
 
         /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHAuthenticator.java
@@ -324,7 +324,13 @@ public abstract class SSHAuthenticator<C, U extends StandardUsernameCredentials>
      * @since 0.5
      */
     private static class Matcher implements CredentialsMatcher {
-	private static final Long serialVersionUID = 1L;
+        /**
+         * Standardize serialization across different JVMs.
+	 *
+	 * @since 1.13
+         */
+	// historical value generated from 1.12 code with Java 8
+	private static final Long serialVersionUID = -5078593817273453864L; 
 
         /**
          * The connection class.

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHAuthenticator.java
@@ -324,6 +324,7 @@ public abstract class SSHAuthenticator<C, U extends StandardUsernameCredentials>
      * @since 0.5
      */
     private static class Matcher implements CredentialsMatcher {
+	private static final Long serialVersionUID = 1L;
 
         /**
          * The connection class.


### PR DESCRIPTION
…ferent platforms.  Matcher needs a serialVersionUID to cover for the many variances of jdk/jre(s) available on different platforms.

https://issues.jenkins-ci.org/browse/JENKINS-39836