### PR TITLE
[JENKINS-46512] Minimal tests update to allow PCT runs with newer bouncy-castle on classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.6</version>
+    <version>2.30</version>
   </parent>
 
   <artifactId>ssh-credentials</artifactId>
@@ -66,8 +66,8 @@
   </scm>
 
   <properties>
-    <jenkins.version>1.609</jenkins.version>
-    <java.level>6</java.level>
+    <jenkins.version>1.651.3</jenkins.version>
+    <java.level>7</java.level>
   </properties>
 
   <repositories>
@@ -102,7 +102,19 @@
     <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-core</artifactId>
-      <version>0.12.0</version>
+      <version>1.3.0</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>bouncycastle-api</artifactId>
+      <version>1.648.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKeyTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKeyTest.java
@@ -32,7 +32,6 @@ import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import java.util.List;
 import hudson.FilePath;
 import hudson.model.Hudson;
-import hudson.remoting.Callable;
 import hudson.security.ACL;
 import jenkins.security.MasterToSlaveCallable;
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/JSchSSHPasswordAuthenticatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/JSchSSHPasswordAuthenticatorTest.java
@@ -31,11 +31,11 @@ import com.jcraft.jsch.HostKeyRepository;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.UserInfo;
 import hudson.model.Items;
-import org.apache.sshd.SshServer;
 import org.apache.sshd.common.NamedFactory;
-import org.apache.sshd.server.PasswordAuthenticator;
-import org.apache.sshd.server.UserAuth;
-import org.apache.sshd.server.auth.UserAuthPassword;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.auth.UserAuth;
+import org.apache.sshd.server.auth.password.PasswordAuthenticator;
+import org.apache.sshd.server.auth.password.UserAuthPasswordFactory;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.session.ServerSession;
 import org.junit.After;
@@ -104,7 +104,7 @@ public class JSchSSHPasswordAuthenticatorTest {
                 return "foomanchu".equals(password);
             }
         });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPassword.Factory()));
+        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPasswordFactory()));
         try {
             sshd.start();
             connector = new JSchConnector(user.getUsername(),"localhost", sshd.getPort());
@@ -136,7 +136,7 @@ public class JSchSSHPasswordAuthenticatorTest {
                 return "foomanchu".equals(password);
             }
         });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPassword.Factory()));
+        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPasswordFactory()));
         try {
             sshd.start();
             connector = new JSchConnector(user.getUsername(),"localhost", sshd.getPort());

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/JSchSSHPublicKeyAuthenticatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/JSchSSHPublicKeyAuthenticatorTest.java
@@ -30,11 +30,11 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.util.Secret;
-import org.apache.sshd.SshServer;
 import org.apache.sshd.common.NamedFactory;
-import org.apache.sshd.server.PublickeyAuthenticator;
-import org.apache.sshd.server.UserAuth;
-import org.apache.sshd.server.auth.UserAuthPublicKey;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.auth.UserAuth;
+import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator;
+import org.apache.sshd.server.auth.pubkey.UserAuthPublicKeyFactory;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.session.ServerSession;
 import org.junit.After;
@@ -145,7 +145,7 @@ public class JSchSSHPublicKeyAuthenticatorTest {
                 return username.equals("foobar");
             }
         });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKey.Factory()));
+        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKeyFactory()));
         try {
             sshd.start();
             connector = new JSchConnector(user.getUsername(), "localhost", sshd.getPort());
@@ -178,7 +178,7 @@ public class JSchSSHPublicKeyAuthenticatorTest {
                 return username.equals("foobar");
             }
         });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKey.Factory()));
+        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKeyFactory()));
         try {
             sshd.start();
             connector = new JSchConnector(user.getUsername(), "localhost", sshd.getPort());

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/TrileadSSHPasswordAuthenticatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/TrileadSSHPasswordAuthenticatorTest.java
@@ -34,11 +34,11 @@ import hudson.model.Items;
 import hudson.slaves.DumbSlave;
 import jenkins.security.MasterToSlaveCallable;
 
-import org.apache.sshd.SshServer;
 import org.apache.sshd.common.NamedFactory;
-import org.apache.sshd.server.PasswordAuthenticator;
-import org.apache.sshd.server.UserAuth;
-import org.apache.sshd.server.auth.UserAuthPassword;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.auth.UserAuth;
+import org.apache.sshd.server.auth.password.PasswordAuthenticator;
+import org.apache.sshd.server.auth.password.UserAuthPasswordFactory;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.session.ServerSession;
 import org.junit.After;
@@ -124,7 +124,7 @@ public class TrileadSSHPasswordAuthenticatorTest {
                 return (username == null || username.equals(_username)) && "foomanchu".equals(password);
             }
         });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPassword.Factory()));
+        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPasswordFactory()));
         return sshd;
     }
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/TrileadSSHPublicKeyAuthenticatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/TrileadSSHPublicKeyAuthenticatorTest.java
@@ -32,11 +32,11 @@ import com.trilead.ssh2.ServerHostKeyVerifier;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.util.Secret;
-import org.apache.sshd.SshServer;
 import org.apache.sshd.common.NamedFactory;
-import org.apache.sshd.server.PublickeyAuthenticator;
-import org.apache.sshd.server.UserAuth;
-import org.apache.sshd.server.auth.UserAuthPublicKey;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.auth.UserAuth;
+import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator;
+import org.apache.sshd.server.auth.pubkey.UserAuthPublicKeyFactory;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.session.ServerSession;
 import org.junit.After;
@@ -145,7 +145,7 @@ public class TrileadSSHPublicKeyAuthenticatorTest {
                 return username.equals("foobar");
             }
         });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKey.Factory()));
+        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKeyFactory()));
         try {
             sshd.start();
             connection = new Connection("localhost", sshd.getPort());
@@ -181,7 +181,7 @@ public class TrileadSSHPublicKeyAuthenticatorTest {
                 return username.equals("foobar");
             }
         });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKey.Factory()));
+        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKeyFactory()));
         try {
             sshd.start();
             connection = new Connection("localhost", sshd.getPort());
@@ -216,7 +216,7 @@ public class TrileadSSHPublicKeyAuthenticatorTest {
                 return username.equals("bill");
             }
         });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKey.Factory()));
+        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKeyFactory()));
         try {
             sshd.start();
             connection = new Connection("localhost", sshd.getPort());


### PR DESCRIPTION
See [JENKINS-46512](https://issues.jenkins-ci.org/browse/JENKINS-46512)

My belief is that the PCT failure is a false-flag and that there is actually no issue with the bouncy-castle upgrade.

The PCT needs to be re-run with this change applied and my claim is that the PCT should pass for the bounct-castle upgrade with the tests fixed to not require a conflicting version of bouncycastle.

@reviewbybees