### PR TITLE
Failures in doAuthenticate should be printed to the supplied listener

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHAuthenticator.java
@@ -31,8 +31,8 @@ import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredenti
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionList;
+import hudson.Functions;
 import hudson.model.BuildListener;
-import hudson.model.Hudson;
 import hudson.model.TaskListener;
 import hudson.remoting.Channel;
 import hudson.util.StreamTaskListener;
@@ -41,8 +41,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import jenkins.security.SlaveToMasterCallable;
 import net.jcip.annotations.GuardedBy;
@@ -437,8 +435,7 @@ public abstract class SSHAuthenticator<C, U extends StandardUsernameCredentials>
                 try {
                     authenticated = doAuthenticate();
                 } catch (Throwable t) {
-                    Logger.getLogger(getClass().getName())
-                            .log(Level.WARNING, "Uncaught exception escaped doAuthenticate method", t);
+                    listener.error("SSH authentication failed").println(Functions.printThrowable(t).trim()); // TODO 2.43+ use Functions.printStackTrace
                     authenticated = false;
                 }
             }


### PR DESCRIPTION
Verified using https://github.com/jenkinsci/acceptance-test-harness/pull/354 against 2.73.1:

```
[09/15/17 11:29:42] [SSH] Opening SSH connection to 127.0.0.1:32776.
[09/15/17 11:29:42] [SSH] WARNING: SSH Host Keys are not being verified. Man-in-the-middle attacks may be possible against this connection.
ERROR: SSH authentication failed
java.lang.NoSuchMethodError: org.mindrot.jbcrypt.BCrypt.pbkdf([B[BI[B)V
	at com.trilead.ssh2.signature.OpenSshCertificateDecoder.generateKayAndIvPbkdf2(OpenSshCertificateDecoder.java:135)
	at com.trilead.ssh2.signature.OpenSshCertificateDecoder.createKeyPair(OpenSshCertificateDecoder.java:78)
	at com.trilead.ssh2.crypto.PEMDecoder.decodeKeyPair(PEMDecoder.java:493)
	at com.trilead.ssh2.auth.AuthenticationManager.authenticatePublicKey(AuthenticationManager.java:225)
	at com.trilead.ssh2.Connection.authenticateWithPublicKey(Connection.java:483)
	at com.cloudbees.jenkins.plugins.sshcredentials.impl.TrileadSSHPublicKeyAuthenticator.doAuthenticate(TrileadSSHPublicKeyAuthenticator.java:109)
	at com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator.authenticate(SSHAuthenticator.java:436)
	at com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator.authenticate(SSHAuthenticator.java:455)
	at hudson.plugins.sshslaves.SSHLauncher.openConnection(SSHLauncher.java:1321)
	at hudson.plugins.sshslaves.SSHLauncher$2.call(SSHLauncher.java:804)
	at hudson.plugins.sshslaves.SSHLauncher$2.call(SSHLauncher.java:793)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:748)
[09/15/17 11:29:42] [SSH] Authentication failed.
Authentication failed.
[09/15/17 11:29:42] Launch failed - cleaning up connection
[09/15/17 11:29:42] [SSH] Connection closed.
```

@reviewbybees