### PR TITLE
[JENKINS-48232] PCT fails against core 2.73+

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPlugin(jenkinsVersions: [null, '2.89.1'])

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
   </scm>
 
   <properties>
-    <jenkins.version>1.609</jenkins.version>
-    <java.level>6</java.level>
+    <jenkins.version>2.7.1</jenkins.version>
+    <java.level>7</java.level>
   </properties>
 
   <repositories>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-core</artifactId>
-      <version>0.12.0</version>
+      <version>1.6.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.7.1</jenkins.version>
-    <java.level>7</java.level>
+    <jenkins.version>1.609</jenkins.version>
+    <java.level>6</java.level>
   </properties>
 
   <repositories>
@@ -99,12 +99,6 @@
     </dependency>
     <!-- jenkins dependencies -->
     <!-- test dependencies -->
-    <dependency>
-      <groupId>org.apache.sshd</groupId>
-      <artifactId>sshd-core</artifactId>
-      <version>1.6.0</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 </project>

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHAuthenticator.java
@@ -232,7 +232,7 @@ public abstract class SSHAuthenticator<C, U extends StandardUsernameCredentials>
      */
     private static List<SSHAuthenticatorFactory> lookupFactories() {
         // TODO once Jenkins core has a class that can be used to detect running on build agent use that to gate instead
-        return Jenkins.getInstance() == null ? null : ExtensionList.lookup(SSHAuthenticatorFactory.class);
+        return Jenkins.getInstanceOrNull() == null ? null : ExtensionList.lookup(SSHAuthenticatorFactory.class);
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHAuthenticator.java
@@ -232,7 +232,7 @@ public abstract class SSHAuthenticator<C, U extends StandardUsernameCredentials>
      */
     private static List<SSHAuthenticatorFactory> lookupFactories() {
         // TODO once Jenkins core has a class that can be used to detect running on build agent use that to gate instead
-        return Jenkins.getInstanceOrNull() == null ? null : ExtensionList.lookup(SSHAuthenticatorFactory.class);
+        return Jenkins.getInstance() == null ? null : ExtensionList.lookup(SSHAuthenticatorFactory.class);
     }
 
     /**

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/JSchSSHPasswordAuthenticatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/JSchSSHPasswordAuthenticatorTest.java
@@ -31,11 +31,11 @@ import com.jcraft.jsch.HostKeyRepository;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.UserInfo;
 import hudson.model.Items;
-import org.apache.sshd.SshServer;
+import org.apache.sshd.server.SshServer;
 import org.apache.sshd.common.NamedFactory;
-import org.apache.sshd.server.PasswordAuthenticator;
-import org.apache.sshd.server.UserAuth;
-import org.apache.sshd.server.auth.UserAuthPassword;
+import org.apache.sshd.server.auth.password.PasswordAuthenticator;
+import org.apache.sshd.server.auth.UserAuth;
+import org.apache.sshd.server.auth.password.UserAuthPasswordFactory;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.session.ServerSession;
 import org.junit.After;
@@ -104,7 +104,7 @@ public class JSchSSHPasswordAuthenticatorTest {
                 return "foomanchu".equals(password);
             }
         });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPassword.Factory()));
+        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPasswordFactory()));
         try {
             sshd.start();
             connector = new JSchConnector(user.getUsername(),"localhost", sshd.getPort());
@@ -136,7 +136,7 @@ public class JSchSSHPasswordAuthenticatorTest {
                 return "foomanchu".equals(password);
             }
         });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPassword.Factory()));
+        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPasswordFactory()));
         try {
             sshd.start();
             connector = new JSchConnector(user.getUsername(),"localhost", sshd.getPort());

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/JSchSSHPasswordAuthenticatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/JSchSSHPasswordAuthenticatorTest.java
@@ -31,20 +31,15 @@ import com.jcraft.jsch.HostKeyRepository;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.UserInfo;
 import hudson.model.Items;
-import org.apache.sshd.server.SshServer;
-import org.apache.sshd.common.NamedFactory;
-import org.apache.sshd.server.auth.password.PasswordAuthenticator;
-import org.apache.sshd.server.auth.UserAuth;
-import org.apache.sshd.server.auth.password.UserAuthPasswordFactory;
-import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
-import org.apache.sshd.server.session.ServerSession;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -96,18 +91,21 @@ public class JSchSSHPasswordAuthenticatorTest {
 
     @Test
     public void testPassword() throws Exception {
-        SshServer sshd = SshServer.setUpDefaultServer();
-        sshd.setPort(0);
-        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
-        sshd.setPasswordAuthenticator(new PasswordAuthenticator() {
-            public boolean authenticate(String username, String password, ServerSession session) {
-                return "foomanchu".equals(password);
-            }
-        });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPasswordFactory()));
+        Object sshd = newDefaultSshServer();
+        Class keyPairProviderClass = newKeyPairProviderClass();
+        Object provider = newProvider();
+        Class authenticatorClass = newAuthenticatorClass();
+        Object authenticator = newAuthenticator(authenticatorClass);
+        Object factory = newFactory();
+
+        invoke(sshd, "setPort", new Class[] {Integer.TYPE}, new Object[] {0});
+        invoke(sshd, "setKeyPairProvider", new Class[] {keyPairProviderClass}, new Object[] {provider});
+        invoke(sshd, "setPasswordAuthenticator", new Class[] {authenticatorClass}, new Object[] {authenticator});
+        invoke(sshd, "setUserAuthFactories", new Class[] {List.class}, new Object[] {Arrays.asList(factory)});
         try {
-            sshd.start();
-            connector = new JSchConnector(user.getUsername(),"localhost", sshd.getPort());
+            invoke(sshd, "start", null, null);
+            int port = (Integer)invoke(sshd, "getPort", null, null);
+            connector = new JSchConnector(user.getUsername(),"localhost", port);
             JSchSSHPasswordAuthenticator instance = new JSchSSHPasswordAuthenticator(connector, user);
             assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.BEFORE_CONNECT));
             assertThat(instance.canAuthenticate(), is(true));
@@ -119,7 +117,7 @@ public class JSchSSHPasswordAuthenticatorTest {
             assertThat(connector.getSession().isConnected(), is(true));
         } finally {
             try {
-                sshd.stop(true);
+                invoke(sshd, "stop", new Class[] {Boolean.TYPE}, new Object[] {true});
             } catch (Throwable t) {
                 Logger.getLogger(getClass().getName()).log(Level.WARNING, "Problems shutting down ssh server", t);
             }
@@ -128,18 +126,21 @@ public class JSchSSHPasswordAuthenticatorTest {
 
     @Test
     public void testFactory() throws Exception {
-        SshServer sshd = SshServer.setUpDefaultServer();
-        sshd.setPort(0);
-        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
-        sshd.setPasswordAuthenticator(new PasswordAuthenticator() {
-            public boolean authenticate(String username, String password, ServerSession session) {
-                return "foomanchu".equals(password);
-            }
-        });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPasswordFactory()));
+        Object sshd = newDefaultSshServer();
+        Class keyPairProviderClass = newKeyPairProviderClass();
+        Object provider = newProvider();
+        Class authenticatorClass = newAuthenticatorClass();
+        Object authenticator = newAuthenticator(authenticatorClass);
+        Object factory = newFactory();
+
+        invoke(sshd, "setPort", new Class[] {Integer.TYPE}, new Object[] {0});
+        invoke(sshd, "setKeyPairProvider", new Class[] {keyPairProviderClass}, new Object[] {provider});
+        invoke(sshd, "setPasswordAuthenticator", new Class[] {authenticatorClass}, new Object[] {authenticator});
+        invoke(sshd, "setUserAuthFactories", new Class[] {List.class}, new Object[] {Arrays.asList(factory)});
         try {
-            sshd.start();
-            connector = new JSchConnector(user.getUsername(),"localhost", sshd.getPort());
+            invoke(sshd, "start", null, null);
+            int port = (Integer)invoke(sshd, "getPort", null, null);
+            connector = new JSchConnector(user.getUsername(),"localhost", port);
             SSHAuthenticator instance = SSHAuthenticator.newInstance(connector, user);
             assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.BEFORE_CONNECT));
             assertThat(instance.canAuthenticate(), is(true));
@@ -151,7 +152,7 @@ public class JSchSSHPasswordAuthenticatorTest {
             assertThat(connector.getSession().isConnected(), is(true));
         } finally {
             try {
-                sshd.stop(true);
+                invoke(sshd, "stop", new Class[] {Boolean.TYPE}, new Object[] {true});
             } catch (Throwable t) {
                 Logger.getLogger(getClass().getName()).log(Level.WARNING, "Problems shutting down ssh server", t);
             }
@@ -184,5 +185,89 @@ public class JSchSSHPasswordAuthenticatorTest {
         public HostKey[] getHostKey(String host, String type) {
             return new HostKey[0];
         }
+    }
+
+
+
+    private Object invoke(Object target, String methodName, Class[] parameterTypes, Object[] args) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        return target.getClass().getMethod(methodName, parameterTypes).invoke(target, args);
+    }
+
+    private Object newDefaultSshServer() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Object sshd = null;
+        Class sshdClass;
+        try {
+            sshdClass = Class.forName("org.apache.sshd.SshServer");
+        } catch (ClassNotFoundException e) {
+            sshdClass = Class.forName("org.apache.sshd.server.SshServer");
+        }
+
+        sshd = sshdClass.getDeclaredMethod("setUpDefaultServer", null).invoke(null);
+        assertNotNull(sshd);
+
+        return sshd;
+    }
+
+    private Class newKeyPairProviderClass() throws ClassNotFoundException {
+        Class keyPairProviderClass;
+        try {
+            keyPairProviderClass = Class.forName("org.apache.sshd.common.KeyPairProvider");
+        } catch (ClassNotFoundException e) {
+            keyPairProviderClass = Class.forName("org.apache.sshd.common.keyprovider.KeyPairProvider");
+        }
+
+        return keyPairProviderClass;
+    }
+
+    private Object newProvider() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        Class providerClass = Class.forName("org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider");
+        Object provider = providerClass.getConstructor().newInstance();
+        assertNotNull(provider);
+
+        return provider;
+    }
+    private Class newAuthenticatorClass() throws ClassNotFoundException {
+        Class authenticatorClass;
+        try {
+            authenticatorClass = Class.forName("org.apache.sshd.server.auth.password.PasswordAuthenticator");
+        } catch(ClassNotFoundException e) {
+            authenticatorClass = Class.forName("org.apache.sshd.server.PasswordAuthenticator");
+        }
+
+        return authenticatorClass;
+    }
+
+    private Object newAuthenticator(Class authenticatorClass) throws ClassNotFoundException, IllegalArgumentException {
+        Object authenticator = java.lang.reflect.Proxy.newProxyInstance(
+                authenticatorClass.getClassLoader(),
+                new java.lang.Class[]{authenticatorClass},
+                new java.lang.reflect.InvocationHandler() {
+
+                    @Override
+                    public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args) throws java.lang.Throwable {
+                        if (method.getName().equals("authenticate")) {
+                            return "foomanchu".equals(args[1]);
+                        }
+
+                        return null;
+                    }
+                });
+        assertNotNull(authenticator);
+        return authenticator;
+    }
+
+    private Object newFactory() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        Object factory = null;
+        Class factoryClass;
+        try {
+            factoryClass = Class.forName("org.apache.sshd.server.auth.UserAuthPassword$Factory");
+        } catch (ClassNotFoundException e) {
+            factoryClass = Class.forName("org.apache.sshd.server.auth.password.UserAuthPasswordFactory");
+        }
+
+        factory = factoryClass.getConstructor().newInstance();
+
+        assertNotNull(factory);
+        return factory;
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/JSchSSHPublicKeyAuthenticatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/JSchSSHPublicKeyAuthenticatorTest.java
@@ -30,11 +30,11 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.util.Secret;
-import org.apache.sshd.SshServer;
+import org.apache.sshd.server.SshServer;
 import org.apache.sshd.common.NamedFactory;
-import org.apache.sshd.server.PublickeyAuthenticator;
-import org.apache.sshd.server.UserAuth;
-import org.apache.sshd.server.auth.UserAuthPublicKey;
+import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator;
+import org.apache.sshd.server.auth.UserAuth;
+import org.apache.sshd.server.auth.pubkey.UserAuthPublicKeyFactory;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.session.ServerSession;
 import org.junit.After;
@@ -145,7 +145,7 @@ public class JSchSSHPublicKeyAuthenticatorTest {
                 return username.equals("foobar");
             }
         });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKey.Factory()));
+        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKeyFactory()));
         try {
             sshd.start();
             connector = new JSchConnector(user.getUsername(), "localhost", sshd.getPort());
@@ -178,7 +178,7 @@ public class JSchSSHPublicKeyAuthenticatorTest {
                 return username.equals("foobar");
             }
         });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKey.Factory()));
+        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKeyFactory()));
         try {
             sshd.start();
             connector = new JSchConnector(user.getUsername(), "localhost", sshd.getPort());

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/JSchSSHPublicKeyAuthenticatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/JSchSSHPublicKeyAuthenticatorTest.java
@@ -30,20 +30,13 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.util.Secret;
-import org.apache.sshd.server.SshServer;
-import org.apache.sshd.common.NamedFactory;
-import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator;
-import org.apache.sshd.server.auth.UserAuth;
-import org.apache.sshd.server.auth.pubkey.UserAuthPublicKeyFactory;
-import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
-import org.apache.sshd.server.session.ServerSession;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import java.security.PublicKey;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -137,18 +130,21 @@ public class JSchSSHPublicKeyAuthenticatorTest {
 
     @Test
     public void testAuthenticate() throws Exception {
-        SshServer sshd = SshServer.setUpDefaultServer();
-        sshd.setPort(0);
-        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
-        sshd.setPublickeyAuthenticator(new PublickeyAuthenticator() {
-            public boolean authenticate(String username, PublicKey key, ServerSession session) {
-                return username.equals("foobar");
-            }
-        });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKeyFactory()));
+        Object sshd = newDefaultSshServer();
+        Class keyPairProviderClass = newKeyPairProviderClass();
+        Object provider = newProvider();
+        Class authenticatorClass = newAuthenticatorClass();
+        Object authenticator = newAuthenticator(authenticatorClass, "foobar");
+        Object factory = newFactory();
+
+        invoke(sshd, "setPort", new Class[] {Integer.TYPE}, new Object[] {0});
+        invoke(sshd, "setKeyPairProvider", new Class[] {keyPairProviderClass}, new Object[] {provider});
+        invoke(sshd, "setPublickeyAuthenticator", new Class[] {authenticatorClass}, new Object[] {authenticator});
+        invoke(sshd, "setUserAuthFactories", new Class[] {List.class}, new Object[] {Arrays.asList(factory)});
         try {
-            sshd.start();
-            connector = new JSchConnector(user.getUsername(), "localhost", sshd.getPort());
+            invoke(sshd, "start", null, null);
+            int port = (Integer)invoke(sshd, "getPort", null, null);
+            connector = new JSchConnector(user.getUsername(), "localhost", port);
             JSchSSHPublicKeyAuthenticator instance =
                     new JSchSSHPublicKeyAuthenticator(connector, user);
             assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.BEFORE_CONNECT));
@@ -161,7 +157,7 @@ public class JSchSSHPublicKeyAuthenticatorTest {
             assertThat(connector.getSession().isConnected(), is(true));
         } finally {
             try {
-                sshd.stop(true);
+                invoke(sshd, "stop", new Class[] {Boolean.TYPE}, new Object[] {true});
             } catch (Throwable t) {
                 Logger.getLogger(getClass().getName()).log(Level.WARNING, "Problems shutting down ssh server", t);
             }
@@ -170,18 +166,21 @@ public class JSchSSHPublicKeyAuthenticatorTest {
 
     @Test
     public void testFactory() throws Exception {
-        SshServer sshd = SshServer.setUpDefaultServer();
-        sshd.setPort(0);
-        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
-        sshd.setPublickeyAuthenticator(new PublickeyAuthenticator() {
-            public boolean authenticate(String username, PublicKey key, ServerSession session) {
-                return username.equals("foobar");
-            }
-        });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKeyFactory()));
+        Object sshd = newDefaultSshServer();
+        Class keyPairProviderClass = newKeyPairProviderClass();
+        Object provider = newProvider();
+        Class authenticatorClass = newAuthenticatorClass();
+        Object authenticator = newAuthenticator(authenticatorClass, "foobar");
+        Object factory = newFactory();
+
+        invoke(sshd, "setPort", new Class[] {Integer.TYPE}, new Object[] {0});
+        invoke(sshd, "setKeyPairProvider", new Class[] {keyPairProviderClass}, new Object[] {provider});
+        invoke(sshd, "setPublickeyAuthenticator", new Class[] {authenticatorClass}, new Object[] {authenticator});
+        invoke(sshd, "setUserAuthFactories", new Class[] {List.class}, new Object[] {Arrays.asList(factory)});
         try {
-            sshd.start();
-            connector = new JSchConnector(user.getUsername(), "localhost", sshd.getPort());
+            invoke(sshd, "start", null, null);
+            int port = (Integer)invoke(sshd, "getPort", null, null);
+            connector = new JSchConnector(user.getUsername(), "localhost", port);
             SSHAuthenticator instance = SSHAuthenticator.newInstance(connector, user);
             assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.BEFORE_CONNECT));
             assertThat(instance.canAuthenticate(), is(true));
@@ -193,10 +192,92 @@ public class JSchSSHPublicKeyAuthenticatorTest {
             assertThat(connector.getSession().isConnected(), is(true));
         } finally {
             try {
-                sshd.stop(true);
+                invoke(sshd, "stop", new Class[] {Boolean.TYPE}, new Object[] {true});
             } catch (Throwable t) {
                 Logger.getLogger(getClass().getName()).log(Level.WARNING, "Problems shutting down ssh server", t);
             }
         }
     }
-}
+
+    private Object invoke(Object target, String methodName, Class[] parameterTypes, Object[] args) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        return target.getClass().getMethod(methodName, parameterTypes).invoke(target, args);
+    }
+
+    private Object newDefaultSshServer() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Object sshd = null;
+        Class sshdClass;
+        try {
+            sshdClass = Class.forName("org.apache.sshd.SshServer");
+        } catch (ClassNotFoundException e) {
+            sshdClass = Class.forName("org.apache.sshd.server.SshServer");
+        }
+
+        sshd = sshdClass.getDeclaredMethod("setUpDefaultServer", null).invoke(null);
+        assertNotNull(sshd);
+
+        return sshd;
+    }
+
+    private Class newKeyPairProviderClass() throws ClassNotFoundException {
+        Class keyPairProviderClass;
+        try {
+            keyPairProviderClass = Class.forName("org.apache.sshd.common.KeyPairProvider");
+        } catch (ClassNotFoundException e) {
+            keyPairProviderClass = Class.forName("org.apache.sshd.common.keyprovider.KeyPairProvider");
+        }
+
+        return keyPairProviderClass;
+    }
+
+    private Object newProvider() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        Class providerClass = Class.forName("org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider");
+        Object provider = providerClass.getConstructor().newInstance();
+        assertNotNull(provider);
+
+        return provider;
+    }
+
+    private Class newAuthenticatorClass() throws ClassNotFoundException {
+        Class authenticatorClass;
+        try {
+            authenticatorClass = Class.forName("org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator");
+        } catch(ClassNotFoundException e) {
+            authenticatorClass = Class.forName("org.apache.sshd.server.PublickeyAuthenticator");
+        }
+
+        return authenticatorClass;
+    }
+
+    private Object newAuthenticator(Class authenticatorClass, final String userName) throws ClassNotFoundException, IllegalArgumentException {
+        Object authenticator = java.lang.reflect.Proxy.newProxyInstance(
+                authenticatorClass.getClassLoader(),
+                new java.lang.Class[]{authenticatorClass},
+                new java.lang.reflect.InvocationHandler() {
+
+                    @Override
+                    public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args) throws java.lang.Throwable {
+                        if (method.getName().equals("authenticate")) {
+                            return userName.equals(args[0]);
+                        }
+
+                        return null;
+                    }
+                });
+        assertNotNull(authenticator);
+        return authenticator;
+    }
+
+    private Object newFactory() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        Object factory = null;
+        Class factoryClass;
+        try {
+            factoryClass = Class.forName("org.apache.sshd.server.auth.UserAuthPublicKey$Factory");
+        } catch (ClassNotFoundException e) {
+            factoryClass = Class.forName("org.apache.sshd.server.auth.pubkey.UserAuthPublicKeyFactory");
+        }
+
+        factory = factoryClass.getConstructor().newInstance();
+
+        assertNotNull(factory);
+        return factory;
+    }}

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/TrileadSSHPasswordAuthenticatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/TrileadSSHPasswordAuthenticatorTest.java
@@ -34,11 +34,11 @@ import hudson.model.Items;
 import hudson.slaves.DumbSlave;
 import jenkins.security.MasterToSlaveCallable;
 
-import org.apache.sshd.SshServer;
+import org.apache.sshd.server.SshServer;
 import org.apache.sshd.common.NamedFactory;
-import org.apache.sshd.server.PasswordAuthenticator;
-import org.apache.sshd.server.UserAuth;
-import org.apache.sshd.server.auth.UserAuthPassword;
+import org.apache.sshd.server.auth.password.PasswordAuthenticator;
+import org.apache.sshd.server.auth.UserAuth;
+import org.apache.sshd.server.auth.password.UserAuthPasswordFactory;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.session.ServerSession;
 import org.junit.After;
@@ -124,7 +124,7 @@ public class TrileadSSHPasswordAuthenticatorTest {
                 return (username == null || username.equals(_username)) && "foomanchu".equals(password);
             }
         });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPassword.Factory()));
+        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPasswordFactory()));
         return sshd;
     }
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/TrileadSSHPasswordAuthenticatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/TrileadSSHPasswordAuthenticatorTest.java
@@ -34,31 +34,27 @@ import hudson.model.Items;
 import hudson.slaves.DumbSlave;
 import jenkins.security.MasterToSlaveCallable;
 
-import org.apache.sshd.server.SshServer;
-import org.apache.sshd.common.NamedFactory;
-import org.apache.sshd.server.auth.password.PasswordAuthenticator;
-import org.apache.sshd.server.auth.UserAuth;
-import org.apache.sshd.server.auth.password.UserAuthPasswordFactory;
-import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
-import org.apache.sshd.server.session.ServerSession;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 public class TrileadSSHPasswordAuthenticatorTest {
 
     private Connection connection;
     private StandardUsernamePasswordCredentials user;
-    private SshServer sshd;
+    private Object sshd;
 
     @Rule public JenkinsRule r = new JenkinsRule();
     
@@ -70,7 +66,7 @@ public class TrileadSSHPasswordAuthenticatorTest {
         }
         if (sshd!=null) {
             try {
-                sshd.stop(true);
+                invoke(sshd, "stop", new Class[] {Boolean.TYPE}, new Object[] {true});
             } catch (Throwable t) {
                 Logger.getLogger(getClass().getName()).log(Level.WARNING, "Problems shutting down ssh server", t);
             }
@@ -100,8 +96,9 @@ public class TrileadSSHPasswordAuthenticatorTest {
     @Test
     public void testPassword() throws Exception {
         sshd = createPasswordAuthenticatedSshServer();
-        sshd.start();
-        connection = new Connection("localhost", sshd.getPort());
+        invoke(sshd, "start", null, null);
+        int port = (Integer)invoke(sshd, "getPort", null, null);
+        connection = new Connection("localhost", port);
         connection.connect(new NoVerifier());
         TrileadSSHPasswordAuthenticator instance =
                 new TrileadSSHPasswordAuthenticator(connection, user);
@@ -111,28 +108,32 @@ public class TrileadSSHPasswordAuthenticatorTest {
         assertThat(instance.isAuthenticated(), is(true));
     }
 
-    private SshServer createPasswordAuthenticatedSshServer() {
+    private Object createPasswordAuthenticatedSshServer() throws InvocationTargetException, NoSuchMethodException, ClassNotFoundException, InstantiationException, IllegalAccessException {
         return createPasswordAuthenticatedSshServer(null);
     }
 
-    private SshServer createPasswordAuthenticatedSshServer(final String username) {
-        SshServer sshd = SshServer.setUpDefaultServer();
-        sshd.setPort(0);
-        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
-        sshd.setPasswordAuthenticator(new PasswordAuthenticator() {
-            public boolean authenticate(String _username, String password, ServerSession session) {
-                return (username == null || username.equals(_username)) && "foomanchu".equals(password);
-            }
-        });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPasswordFactory()));
+    private Object createPasswordAuthenticatedSshServer(final String username) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, ClassNotFoundException, InstantiationException {
+        Object sshd = newDefaultSshServer();
+        Class keyPairProviderClass = newKeyPairProviderClass();
+        Object provider = newProvider();
+        Class authenticatorClass = newAuthenticatorClass();
+        Object authenticator = newAuthenticator(authenticatorClass, username);
+        Object factory = newFactory();
+
+        invoke(sshd, "setPort", new Class[] {Integer.TYPE}, new Object[] {0});
+        invoke(sshd, "setKeyPairProvider", new Class[] {keyPairProviderClass}, new Object[] {provider});
+        invoke(sshd, "setPasswordAuthenticator", new Class[] {authenticatorClass}, new Object[] {authenticator});
+        invoke(sshd, "setUserAuthFactories", new Class[] {List.class}, new Object[] {Arrays.asList(factory)});
+
         return sshd;
     }
 
     @Test
     public void testFactory() throws Exception {
         sshd = createPasswordAuthenticatedSshServer();
-        sshd.start();
-        connection = new Connection("localhost", sshd.getPort());
+        invoke(sshd, "start", null, null);
+        int port = (Integer)invoke(sshd, "getPort", null, null);
+        connection = new Connection("localhost", port);
         connection.connect(new NoVerifier());
         SSHAuthenticator instance = SSHAuthenticator.newInstance(connection, user);
         assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.AFTER_CONNECT));
@@ -144,15 +145,16 @@ public class TrileadSSHPasswordAuthenticatorTest {
     @Test
     public void testFactoryAltUsername() throws Exception {
         sshd = createPasswordAuthenticatedSshServer("bill");
-        sshd.start();
-        connection = new Connection("localhost", sshd.getPort());
+        invoke(sshd, "start", null, null);
+        int port = (Integer)invoke(sshd, "getPort", null, null);
+        connection = new Connection("localhost", port);
         connection.connect(new NoVerifier());
         SSHAuthenticator instance = SSHAuthenticator.newInstance(connection, user, null);
         assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.AFTER_CONNECT));
         assertThat(instance.canAuthenticate(), is(true));
         assertThat(instance.authenticate(), is(false));
         assertThat(instance.isAuthenticated(), is(false));
-        connection = new Connection("localhost", sshd.getPort());
+        connection = new Connection("localhost", port);
         connection.connect(new NoVerifier());
         instance = SSHAuthenticator.newInstance(connection, user, "bill");
         assertThat(instance.getAuthenticationMode(), is(SSHAuthenticator.Mode.AFTER_CONNECT));
@@ -166,14 +168,14 @@ public class TrileadSSHPasswordAuthenticatorTest {
      */
     @Test
     public void testSlave() throws Exception {
-        SshServer sshd = createPasswordAuthenticatedSshServer();
-        sshd.start();
+        Object sshd = createPasswordAuthenticatedSshServer();
+        invoke(sshd, "start", null, null);
 
         DumbSlave s = r.createSlave();
         Computer c = s.toComputer();
         c.connect(false).get();
 
-        final int port = sshd.getPort();
+        final int port = (Integer)invoke(sshd, "getPort", null, null);
 
         c.getChannel().call(new RemoteConnectionTest(port,user));
     }
@@ -208,5 +210,88 @@ public class TrileadSSHPasswordAuthenticatorTest {
         }
 
         private static final long serialVersionUID = 1L;
+    }
+
+    private Object invoke(Object target, String methodName, Class[] parameterTypes, Object[] args) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        return target.getClass().getMethod(methodName, parameterTypes).invoke(target, args);
+    }
+
+    private Object newDefaultSshServer() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Object server = null;
+        Class serverClass;
+        try {
+            serverClass = Class.forName("org.apache.sshd.SshServer");
+        } catch (ClassNotFoundException e) {
+            serverClass = Class.forName("org.apache.sshd.server.SshServer");
+        }
+
+        server = serverClass.getDeclaredMethod("setUpDefaultServer", null).invoke(null);
+        assertNotNull(server);
+
+        return server;
+    }
+
+    private Class newKeyPairProviderClass() throws ClassNotFoundException {
+        Class keyPairProviderClass;
+        try {
+            keyPairProviderClass = Class.forName("org.apache.sshd.common.KeyPairProvider");
+        } catch (ClassNotFoundException e) {
+            keyPairProviderClass = Class.forName("org.apache.sshd.common.keyprovider.KeyPairProvider");
+        }
+
+        return keyPairProviderClass;
+    }
+
+    private Object newProvider() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        Class providerClass = Class.forName("org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider");
+        Object provider = providerClass.getConstructor().newInstance();
+        assertNotNull(provider);
+
+        return provider;
+    }
+
+    private Class newAuthenticatorClass() throws ClassNotFoundException {
+        Class authenticatorClass;
+        try {
+            authenticatorClass = Class.forName("org.apache.sshd.server.auth.password.PasswordAuthenticator");
+        } catch(ClassNotFoundException e) {
+            authenticatorClass = Class.forName("org.apache.sshd.server.PasswordAuthenticator");
+        }
+
+        return authenticatorClass;
+    }
+
+    private Object newAuthenticator(Class authenticatorClass, final String userName) throws ClassNotFoundException, IllegalArgumentException {
+        Object authenticator = java.lang.reflect.Proxy.newProxyInstance(
+                authenticatorClass.getClassLoader(),
+                new java.lang.Class[]{authenticatorClass},
+                new java.lang.reflect.InvocationHandler() {
+
+                    @Override
+                    public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args) throws java.lang.Throwable {
+                        if (method.getName().equals("authenticate")) {
+                            return (userName == null || userName.equals(args[0])) && "foomanchu".equals(args[1]);
+                        }
+
+                        return null;
+                    }
+                });
+        assertNotNull(authenticator);
+        return authenticator;
+    }
+
+    private Object newFactory() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        Object factory = null;
+        Class factoryClass;
+        try {
+            factoryClass = Class.forName("org.apache.sshd.server.auth.UserAuthPassword$Factory");
+        } catch (ClassNotFoundException e) {
+            factoryClass = Class.forName("org.apache.sshd.server.auth.password.UserAuthPasswordFactory");
+        }
+
+        factory = factoryClass.getConstructor().newInstance();
+
+        assertNotNull(factory);
+        return factory;
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/TrileadSSHPublicKeyAuthenticatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/TrileadSSHPublicKeyAuthenticatorTest.java
@@ -32,11 +32,11 @@ import com.trilead.ssh2.ServerHostKeyVerifier;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.util.Secret;
-import org.apache.sshd.SshServer;
+import org.apache.sshd.server.SshServer;
 import org.apache.sshd.common.NamedFactory;
-import org.apache.sshd.server.PublickeyAuthenticator;
-import org.apache.sshd.server.UserAuth;
-import org.apache.sshd.server.auth.UserAuthPublicKey;
+import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator;
+import org.apache.sshd.server.auth.UserAuth;
+import org.apache.sshd.server.auth.pubkey.UserAuthPublicKeyFactory;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.session.ServerSession;
 import org.junit.After;
@@ -145,7 +145,7 @@ public class TrileadSSHPublicKeyAuthenticatorTest {
                 return username.equals("foobar");
             }
         });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKey.Factory()));
+        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKeyFactory()));
         try {
             sshd.start();
             connection = new Connection("localhost", sshd.getPort());
@@ -181,7 +181,7 @@ public class TrileadSSHPublicKeyAuthenticatorTest {
                 return username.equals("foobar");
             }
         });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKey.Factory()));
+        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKeyFactory()));
         try {
             sshd.start();
             connection = new Connection("localhost", sshd.getPort());
@@ -216,7 +216,7 @@ public class TrileadSSHPublicKeyAuthenticatorTest {
                 return username.equals("bill");
             }
         });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKey.Factory()));
+        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKeyFactory()));
         try {
             sshd.start();
             connection = new Connection("localhost", sshd.getPort());

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/TrileadSSHPublicKeyAuthenticatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/TrileadSSHPublicKeyAuthenticatorTest.java
@@ -32,20 +32,14 @@ import com.trilead.ssh2.ServerHostKeyVerifier;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.util.Secret;
-import org.apache.sshd.server.SshServer;
-import org.apache.sshd.common.NamedFactory;
-import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator;
-import org.apache.sshd.server.auth.UserAuth;
-import org.apache.sshd.server.auth.pubkey.UserAuthPublicKeyFactory;
-import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
-import org.apache.sshd.server.session.ServerSession;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import java.security.PublicKey;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -53,6 +47,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 public class TrileadSSHPublicKeyAuthenticatorTest {
@@ -137,18 +132,23 @@ public class TrileadSSHPublicKeyAuthenticatorTest {
 
     @Test
     public void testAuthenticate() throws Exception {
-        SshServer sshd = SshServer.setUpDefaultServer();
-        sshd.setPort(0);
-        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
-        sshd.setPublickeyAuthenticator(new PublickeyAuthenticator() {
-            public boolean authenticate(String username, PublicKey key, ServerSession session) {
-                return username.equals("foobar");
-            }
-        });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKeyFactory()));
+        Object sshd = newDefaultSshServer();
+        Class keyPairProviderClass = newKeyPairProviderClass();
+        Object provider = newProvider();
+        Class authenticatorClass = newAuthenticatorClass();
+        Object authenticator = newAuthenticator(authenticatorClass, "foobar");
+        Object factory = newFactory();
+        assertNotNull(factory);
+
+        invoke(sshd, "setPort", new Class[] {Integer.TYPE}, new Object[] {0});
+        invoke(sshd, "setKeyPairProvider", new Class[] {keyPairProviderClass}, new Object[] {provider});
+        invoke(sshd, "setPublickeyAuthenticator", new Class[] {authenticatorClass}, new Object[] {authenticator});
+        invoke(sshd, "setUserAuthFactories", new Class[] {List.class}, new Object[] {Arrays.asList(factory)});
+
         try {
-            sshd.start();
-            connection = new Connection("localhost", sshd.getPort());
+            invoke(sshd, "start", null, null);
+            int port = (Integer)invoke(sshd, "getPort", null, null);
+            connection = new Connection("localhost", port);
             connection.connect(new ServerHostKeyVerifier() {
                 public boolean verifyServerHostKey(String hostname, int port, String serverHostKeyAlgorithm,
                                                    byte[] serverHostKey)
@@ -164,7 +164,7 @@ public class TrileadSSHPublicKeyAuthenticatorTest {
             assertThat(instance.isAuthenticated(), is(true));
         } finally {
             try {
-                sshd.stop(true);
+                invoke(sshd, "stop", new Class[] {Boolean.TYPE}, new Object[] {true});
             } catch (Throwable t) {
                 Logger.getLogger(getClass().getName()).log(Level.WARNING, "Problems shutting down ssh server", t);
             }
@@ -173,18 +173,22 @@ public class TrileadSSHPublicKeyAuthenticatorTest {
 
     @Test
     public void testFactory() throws Exception {
-        SshServer sshd = SshServer.setUpDefaultServer();
-        sshd.setPort(0);
-        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
-        sshd.setPublickeyAuthenticator(new PublickeyAuthenticator() {
-            public boolean authenticate(String username, PublicKey key, ServerSession session) {
-                return username.equals("foobar");
-            }
-        });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKeyFactory()));
+        Object sshd = newDefaultSshServer();
+        Class keyPairProviderClass = newKeyPairProviderClass();
+        Object provider = newProvider();
+        Class authenticatorClass = newAuthenticatorClass();
+        Object authenticator = newAuthenticator(authenticatorClass, "foobar");
+        Object factory = newFactory();
+        assertNotNull(factory);
+
+        invoke(sshd, "setPort", new Class[] {Integer.TYPE}, new Object[] {0});
+        invoke(sshd, "setKeyPairProvider", new Class[] {keyPairProviderClass}, new Object[] {provider});
+        invoke(sshd, "setPublickeyAuthenticator", new Class[] {authenticatorClass}, new Object[] {authenticator});
+        invoke(sshd, "setUserAuthFactories", new Class[] {List.class}, new Object[] {Arrays.asList(factory)});
         try {
-            sshd.start();
-            connection = new Connection("localhost", sshd.getPort());
+            invoke(sshd, "start", null, null);
+            int port = (Integer)invoke(sshd, "getPort", null, null);
+            connection = new Connection("localhost", port);
             connection.connect(new ServerHostKeyVerifier() {
                 public boolean verifyServerHostKey(String hostname, int port, String serverHostKeyAlgorithm,
                                                    byte[] serverHostKey)
@@ -199,7 +203,7 @@ public class TrileadSSHPublicKeyAuthenticatorTest {
             assertThat(instance.isAuthenticated(), is(true));
         } finally {
             try {
-                sshd.stop(true);
+                invoke(sshd, "stop", new Class[] {Boolean.TYPE}, new Object[] {true});
             } catch (Throwable t) {
                 Logger.getLogger(getClass().getName()).log(Level.WARNING, "Problems shutting down ssh server", t);
             }
@@ -208,18 +212,21 @@ public class TrileadSSHPublicKeyAuthenticatorTest {
 
     @Test
     public void testAltUsername() throws Exception {
-        SshServer sshd = SshServer.setUpDefaultServer();
-        sshd.setPort(0);
-        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
-        sshd.setPublickeyAuthenticator(new PublickeyAuthenticator() {
-            public boolean authenticate(String username, PublicKey key, ServerSession session) {
-                return username.equals("bill");
-            }
-        });
-        sshd.setUserAuthFactories(Arrays.<NamedFactory<UserAuth>>asList(new UserAuthPublicKeyFactory()));
+        Object sshd = newDefaultSshServer();
+        Class keyPairProviderClass = newKeyPairProviderClass();
+        Object provider = newProvider();
+        Class authenticatorClass = newAuthenticatorClass();
+        Object authenticator = newAuthenticator(authenticatorClass, "bill");
+        Object factory = newFactory();
+
+        invoke(sshd, "setPort", new Class[] {Integer.TYPE}, new Object[] {0});
+        invoke(sshd, "setKeyPairProvider", new Class[] {keyPairProviderClass}, new Object[] {provider});
+        invoke(sshd, "setPublickeyAuthenticator", new Class[] {authenticatorClass}, new Object[] {authenticator});
+        invoke(sshd, "setUserAuthFactories", new Class[] {List.class}, new Object[] {Arrays.asList(factory)});
         try {
-            sshd.start();
-            connection = new Connection("localhost", sshd.getPort());
+            invoke(sshd, "start", null, null);
+            int port = (Integer)invoke(sshd, "getPort", null, null);
+            connection = new Connection("localhost", port);
             connection.connect(new ServerHostKeyVerifier() {
                 public boolean verifyServerHostKey(String hostname, int port, String serverHostKeyAlgorithm,
                                                    byte[] serverHostKey)
@@ -232,7 +239,7 @@ public class TrileadSSHPublicKeyAuthenticatorTest {
             assertThat(instance.canAuthenticate(), is(true));
             assertThat(instance.authenticate(), is(false));
             assertThat(instance.isAuthenticated(), is(false));
-            connection = new Connection("localhost", sshd.getPort());
+            connection = new Connection("localhost", port);
             connection.connect(new ServerHostKeyVerifier() {
                 public boolean verifyServerHostKey(String hostname, int port, String serverHostKeyAlgorithm,
                                                    byte[] serverHostKey)
@@ -247,10 +254,93 @@ public class TrileadSSHPublicKeyAuthenticatorTest {
             assertThat(instance.isAuthenticated(), is(true));
         } finally {
             try {
-                sshd.stop(true);
+                invoke(sshd, "stop", new Class[] {Boolean.TYPE}, new Object[] {true});
             } catch (Throwable t) {
                 Logger.getLogger(getClass().getName()).log(Level.WARNING, "Problems shutting down ssh server", t);
             }
         }
+    }
+
+    private Object invoke(Object target, String methodName, Class[] parameterTypes, Object[] args) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        return target.getClass().getMethod(methodName, parameterTypes).invoke(target, args);
+    }
+
+    private Object newDefaultSshServer() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Object sshd = null;
+        Class sshdClass;
+        try {
+            sshdClass = Class.forName("org.apache.sshd.SshServer");
+        } catch (ClassNotFoundException e) {
+            sshdClass = Class.forName("org.apache.sshd.server.SshServer");
+        }
+
+        sshd = sshdClass.getDeclaredMethod("setUpDefaultServer", null).invoke(null);
+        assertNotNull(sshd);
+
+        return sshd;
+    }
+
+    private Class newKeyPairProviderClass() throws ClassNotFoundException {
+        Class keyPairProviderClass;
+        try {
+            keyPairProviderClass = Class.forName("org.apache.sshd.common.KeyPairProvider");
+        } catch (ClassNotFoundException e) {
+            keyPairProviderClass = Class.forName("org.apache.sshd.common.keyprovider.KeyPairProvider");
+        }
+
+        return keyPairProviderClass;
+    }
+
+    private Object newProvider() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        Class providerClass = Class.forName("org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider");
+        Object provider = providerClass.getConstructor().newInstance();
+        assertNotNull(provider);
+
+        return provider;
+    }
+
+    private Class newAuthenticatorClass() throws ClassNotFoundException {
+        Class authenticatorClass;
+        try {
+            authenticatorClass = Class.forName("org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator");
+        } catch(ClassNotFoundException e) {
+            authenticatorClass = Class.forName("org.apache.sshd.server.PublickeyAuthenticator");
+        }
+
+        return authenticatorClass;
+    }
+
+    private Object newAuthenticator(Class authenticatorClass, final String userName) throws ClassNotFoundException, IllegalArgumentException {
+        Object authenticator = java.lang.reflect.Proxy.newProxyInstance(
+                authenticatorClass.getClassLoader(),
+                new java.lang.Class[]{authenticatorClass},
+                new java.lang.reflect.InvocationHandler() {
+
+                    @Override
+                    public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args) throws java.lang.Throwable {
+                        if (method.getName().equals("authenticate")) {
+                            return userName.equals(args[0]);
+                        }
+
+                        return null;
+                    }
+                });
+        assertNotNull(authenticator);
+        return authenticator;
+    }
+
+    private Object newFactory() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        Object factory = null;
+        Class factoryClass;
+        try {
+            factoryClass = Class.forName("org.apache.sshd.server.auth.UserAuthPublicKey$Factory");
+        } catch (ClassNotFoundException e) {
+            factoryClass = Class.forName("org.apache.sshd.server.auth.pubkey.UserAuthPublicKeyFactory");
+        }
+
+        factory = factoryClass.getConstructor().newInstance();
+
+        assertNotNull(factory);
+        return factory;
     }
 }


### PR DESCRIPTION
See [JENKINS-48232](https://issues.jenkins-ci.org/browse/JENKINS-48232)

## Features:

- Upgrade test dependency: `jenkins-core:2.73` needs `sshd-core:1.6.0` and therefore update tests.
- Upgrading baseline to `jenkins.version:2.7` to prevent `IndexOutOfBoundsException` when the `ExtensionList` is recovered.
- Update `SSHAutenticator` to use `Jenkins.getInstanceOrNull()` instead of `Jenkins.getInstance()` to match with findbug and prevent `NullPointerException`.

@reviewbybees esp. @stephenc 