### PR TITLE
[JENKINS-50181] add trailing newline to private keys entered in web UI to appease ssh-add

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey.java
@@ -311,7 +311,7 @@ public class BasicSSHUserPrivateKey extends BaseSSHUser implements SSHUserPrivat
         private final Secret privateKey;
 
         public DirectEntryPrivateKeySource(String privateKey) {
-            this(Secret.fromString(privateKey));
+            this(Secret.fromString(privateKey.endsWith("\n") ? privateKey : privateKey + "\n"));
         }
 
         @DataBoundConstructor

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKeyTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKeyTest.java
@@ -76,6 +76,12 @@ public class BasicSSHUserPrivateKeyTest {
         assertTrue(privateKey.endsWith(TESTKEY_END));
     }
 
+    @Test
+    public void ensureDirectEntryHasTrailingNewline() throws Exception {
+        String key = (new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource("test")).getPrivateKey().toString();
+        assertEquals("test\n", key);
+    }
+
     // TODO demonstrate that all private key sources are round-tripped in XStream
 
     @Test


### PR DESCRIPTION
Per [JENKINS-50181](https://issues.jenkins-ci.org/browse/JENKINS-50181).

If there's no trailing newline ssh-add will get upset and either refuse the key with `Error loading key "<path>": invalid format` or prompt for a password when the key does not have one and fail.

I don't know that the ternary is idiomatic, so please let me know if there's anything smelly. Ty!