### PR TITLE
[JENKINS-52175] Increase test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.33</version>
+    <version>3.1</version>
   </parent>
 
   <artifactId>ssh-credentials</artifactId>
@@ -66,8 +66,8 @@
   </scm>
 
   <properties>
-    <jenkins.version>1.609</jenkins.version>
-    <java.level>6</java.level>
+    <jenkins.version>1.625.3</jenkins.version>
+    <java.level>7</java.level>
   </properties>
 
   <repositories>
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.0</version>
+      <version>2.1.17-SNAPSHOT</version>
     </dependency>
     <!-- jenkins dependencies -->
     <!-- test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.18-SNAPSHOT</version>
+      <version>2.1.18</version>
     </dependency>
     <!-- jenkins dependencies -->
     <!-- test dependencies -->

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/CLICommandsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/CLICommandsTest.java
@@ -1,0 +1,85 @@
+package com.cloudbees.jenkins.plugins.sshcredentials.impl;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.cli.ListCredentialsAsXmlCommand;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.domains.DomainSpecification;
+import com.cloudbees.plugins.credentials.domains.HostnameSpecification;
+import hudson.cli.CLICommandInvoker;
+import jenkins.model.Jenkins;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static hudson.cli.CLICommandInvoker.Matcher.succeeded;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+public class CLICommandsTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    private CredentialsStore store = null;
+
+    @Before
+    public void clearCredentials() {
+        SystemCredentialsProvider.getInstance().setDomainCredentialsMap(
+                Collections.singletonMap(Domain.global(), Collections.<Credentials>emptyList()));
+        for (CredentialsStore s : CredentialsProvider.lookupStores(Jenkins.getInstance())) {
+            if (s.getProvider() instanceof SystemCredentialsProvider.ProviderImpl) {
+                store = s;
+                break;
+            }
+        }
+        assertThat("The system credentials provider is enabled", store, notNullValue());
+    }
+
+    @Test
+    public void listCredentialsAsXML() throws IOException {
+        Domain smokes = new Domain("smokes", "smoke test domain",
+                Collections.<DomainSpecification>singletonList(new HostnameSpecification("smokes.example.com", null)));
+        BasicSSHUserPrivateKey credentials1 = new BasicSSHUserPrivateKey(CredentialsScope.GLOBAL, "smokes-id-1", "john.doe",
+                new BasicSSHUserPrivateKey.FileOnMasterPrivateKeySource("/tmp/test"),
+                "passphrase",
+                "Smokes CLI Command Test");
+        BasicSSHUserPrivateKey credentials2 = new BasicSSHUserPrivateKey(CredentialsScope.GLOBAL, "smokes-id-2", "john.doe",
+                new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource("test"),
+                "passphrase",
+                "Smokes CLI Command Test");
+        BasicSSHUserPrivateKey credentials3 = new BasicSSHUserPrivateKey(CredentialsScope.GLOBAL, "smokes-id-3", "john.doe",
+                new BasicSSHUserPrivateKey.UsersPrivateKeySource(),
+                "passphrase",
+                "Smokes CLI Command Test");
+        CLICommandInvoker invoker = new CLICommandInvoker(r, new ListCredentialsAsXmlCommand());
+        CLICommandInvoker.Result result = invoker.invokeWithArgs("system::system::jenkins");
+        assertThat(result, succeeded());
+        assertThat(result.stdout(), not(containsString("<id>smokes-id</id>")));
+
+        store.addDomain(smokes, credentials1);
+        store.addDomain(smokes, credentials2);
+        store.addDomain(smokes, credentials3);
+
+        invoker = new CLICommandInvoker(r, new ListCredentialsAsXmlCommand());
+        result = invoker.invokeWithArgs("system::system::jenkins");
+        System.out.println(result.stdout());
+        assertThat(result, succeeded());
+        assertThat(result.stdout(), allOf(
+                containsString("<id>smokes-id-1</id>"),
+                containsString("<id>smokes-id-2</id>"),
+                containsString("<id>smokes-id-3</id>"),
+                containsString("<name>smokes</name>"),
+                containsString("<com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey>"),
+                containsString("<privateKeySource class=\"com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey$FileOnMasterPrivateKeySource\">"),
+                containsString("<privateKeySource class=\"com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey$DirectEntryPrivateKeySource\">"),
+                containsString("<privateKeySource class=\"com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey$UsersPrivateKeySource\"/>")
+        ));
+    }
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/sshcredentials/impl/credentials-input.xml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/sshcredentials/impl/credentials-input.xml
@@ -1,0 +1,49 @@
+<list>
+    <com.cloudbees.plugins.credentials.domains.DomainCredentials>
+        <domain>
+            <specifications/>
+        </domain>
+        <credentials/>
+    </com.cloudbees.plugins.credentials.domains.DomainCredentials>
+    <com.cloudbees.plugins.credentials.domains.DomainCredentials>
+        <domain>
+            <name>smokes</name>
+            <description>smoke test domain</description>
+            <specifications>
+                <com.cloudbees.plugins.credentials.domains.HostnameSpecification>
+                    <includes>smokes.example.com</includes>
+                </com.cloudbees.plugins.credentials.domains.HostnameSpecification>
+            </specifications>
+        </domain>
+        <credentials>
+            <com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey>
+                <scope>GLOBAL</scope>
+                <id>smokes-id-1</id>
+                <description>Smokes CLI Command Test</description>
+                <username>john.doe</username>
+                <passphrase>test</passphrase>
+                <privateKeySource class="com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey$FileOnMasterPrivateKeySource">
+                    <privateKeyFile>/tmp/test</privateKeyFile>
+                </privateKeySource>
+            </com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey>
+            <com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey>
+                <scope>GLOBAL</scope>
+                <id>smokes-id-2</id>
+                <description>Smokes CLI Command Test</description>
+                <username>john.doe</username>
+                <passphrase>passphrase</passphrase>
+                <privateKeySource class="com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey$DirectEntryPrivateKeySource">
+                    <privateKey>aprivatekey</privateKey>
+                </privateKeySource>
+            </com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey>
+            <com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey>
+                <scope>GLOBAL</scope>
+                <id>smokes-id-3</id>
+                <description>Smokes CLI Command Test</description>
+                <username>john.doe</username>
+                <passphrase>passphrase</passphrase>
+                <privateKeySource class="com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey$UsersPrivateKeySource"/>
+            </com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey>
+        </credentials>
+    </com.cloudbees.plugins.credentials.domains.DomainCredentials>
+</list>


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/credentials-plugin/pull/101

This is adding a test to cover the new CLI endpoint in credentials-plugin, which should be producing correct XML output for credentials types defined by this plugin.

@reviewbybees 