### PR TITLE
Use secretTextarea for SSH key UI

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.0-beta-7</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <!-- TODO: after upgrading jenkins.version >= 2.171, migrate dependency -->
       <groupId>io.jenkins.temp.jelly</groupId>
       <artifactId>multiline-secrets-ui</artifactId>
       <version>1.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,11 @@
       <version>0.1.55</version>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins.temp.jelly</groupId>
+      <artifactId>multiline-secrets-ui</artifactId>
+      <version>1.0</version>
+    </dependency>
     <!-- plugin dependencies -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   </parent>
 
   <artifactId>ssh-credentials</artifactId>
-  <version>1.16-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
 
   <name>SSH Credentials Plugin</name>
@@ -66,10 +66,12 @@
     <connection>scm:git:git://github.com/jenkinsci/ssh-credentials-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/ssh-credentials-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/ssh-credentials-plugin</url>
-    <tag>HEAD</tag>
+    <tag>${scmTag}</tag>
   </scm>
 
   <properties>
+    <revision>1.16</revision>
+    <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.73.3</jenkins.version>
     <java.level>8</java.level>
   </properties>

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey.java
@@ -337,8 +337,8 @@ public class BasicSSHUserPrivateKey extends BaseSSHUser implements SSHUserPrivat
          * @return the private key.
          */
         @SuppressWarnings("unused") // used by Jelly EL
-        public String getPrivateKey() {
-            return Secret.toString(privateKey);
+        public Secret getPrivateKey() {
+            return privateKey;
         }
 
         /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey.java
@@ -310,9 +310,13 @@ public class BasicSSHUserPrivateKey extends BaseSSHUser implements SSHUserPrivat
 
         private final Secret privateKey;
 
-        @DataBoundConstructor
         public DirectEntryPrivateKeySource(String privateKey) {
-            this.privateKey = Secret.fromString(privateKey);
+            this(Secret.fromString(privateKey));
+        }
+
+        @DataBoundConstructor
+        public DirectEntryPrivateKeySource(Secret privateKey) {
+            this.privateKey = privateKey;
         }
 
         public DirectEntryPrivateKeySource(List<String> privateKeys) {

--- a/src/main/resources/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey/DirectEntryPrivateKeySource/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey/DirectEntryPrivateKeySource/config.jelly
@@ -26,6 +26,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:entry title="${%Key}" field="privateKey">
-    <f:textarea/>
+    <secretTextarea xmlns="/io/jenkins/temp/jelly"/>
   </f:entry>
 </j:jelly>


### PR DESCRIPTION
Using the backport from https://github.com/jenkinsci/jenkins/pull/3967

This replaces the textarea form input for SSH keys with a new custom editor for multiline secrets. See the above PR for screenshots.