### PR TITLE
Remove myself from developers in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,10 +57,6 @@
       <name>Oleg Nenashev</name>
     </developer>
     <developer>
-      <id>dnusbaum</id>
-      <name>Devin Nusbaum</name>
-    </developer>
-    <developer>
       <id>jvz</id>
       <name>Matt Sicker</name>
     </developer>


### PR DESCRIPTION
As far as I know I never had [release permissions](https://github.com/jenkins-infra/repository-permissions-updater/blob/cd9288192cc76ccd47daae7499af69fa0f9db677/permissions/plugin-ssh-credentials.yml) or GitHub write permissions, and I've never contributed to the plugin, so it doesn't really make sense for me to be listed here. I was originally added in #32, but that PR ended up getting merged about a year after it was opened and I had since moved to a new team working on other areas of Jenkins.