### PR TITLE
Update baseline to 2.190.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,4 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(configurations: [
+    [platform: 'linux', jdk: '8'],
+    [platform: 'windows', jdk: '8']
+], useAci: true)

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.43</version>
+    <version>3.50</version>
     <relativePath />
   </parent>
 
@@ -70,10 +70,12 @@
   </scm>
 
   <properties>
-    <revision>1.17.4</revision>
+    <revision>1.18.0</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.138.4</jenkins.version>
+    <jenkins.version>2.190.1</jenkins.version>
     <java.level>8</java.level>
+    <slf4jVersion>1.7.26</slf4jVersion> <!-- TODO pending https://github.com/jenkinsci/plugin-pom/pull/229 -->
+    <!-- TODO use BOM after https://github.com/jenkinsci/bom/pull/110 -->
     <jcasc.version>1.30</jcasc.version>
   </properties>
 
@@ -99,10 +101,9 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <!-- TODO: after upgrading jenkins.version >= 2.171, migrate dependency -->
-      <groupId>io.jenkins.temp.jelly</groupId>
-      <artifactId>multiline-secrets-ui</artifactId>
-      <version>1.0</version>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>trilead-api</artifactId>
+      <version>1.0.5</version>
     </dependency>
     <!-- plugin dependencies -->
     <dependency>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey/DirectEntryPrivateKeySource/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey/DirectEntryPrivateKeySource/config.jelly
@@ -26,6 +26,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:entry title="${%Key}" field="privateKey">
-    <secretTextarea xmlns="/io/jenkins/temp/jelly"/>
+    <f:secretTextarea/>
   </f:entry>
 </j:jelly>


### PR DESCRIPTION
For two reasons:

* So that downstream plugins on 2.190.x do not have to figure out how to deal with https://github.com/jenkinsci/jenkins/pull/4085.
* To amend #40 to use the official API.