### PR TITLE
Provide a default implementation of `SSHUserPrivateKey#getPrivateKey`

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHUserPrivateKey.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/SSHUserPrivateKey.java
@@ -41,7 +41,10 @@ public interface SSHUserPrivateKey extends SSHUser {
      */
     @Deprecated
     @NonNull
-    String getPrivateKey();
+    default String getPrivateKey() {
+        List<String> keys = getPrivateKeys();
+        return keys.isEmpty() ? "" : keys.get(0);
+    }
 
     /**
      * Gets the passphrase for the private keys or {@code null} if the private keys are not protected by a

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey.java
@@ -147,15 +147,6 @@ public class BasicSSHUserPrivateKey extends BaseSSHUser implements SSHUserPrivat
         return super.readResolve();
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @NonNull
-    public String getPrivateKey() {
-        List<String> privateKeys = getPrivateKeys();
-        return privateKeys.isEmpty() ? "" : privateKeys.get(0);
-    }
-
     @NonNull
     public synchronized List<String> getPrivateKeys() {
         if (privateKeySource == null) {

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/TrileadSSHPublicKeyAuthenticatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/TrileadSSHPublicKeyAuthenticatorTest.java
@@ -99,11 +99,16 @@ public class TrileadSSHPublicKeyAuthenticatorTest {
                 };
             }
 
+            @CheckForNull
+            public Secret getPassphrase() {
+                return null;
+            }
+
             @NonNull
-            public String getPrivateKey() {
+            public List<String> getPrivateKeys() {
                 // just want a valid key... I generated this and have thrown it away (other than here)
                 // do not use other than in this test
-                return "-----BEGIN RSA PRIVATE KEY-----\n"
+                return List.of("-----BEGIN RSA PRIVATE KEY-----\n"
                         + "MIICWQIBAAKBgQDADDwooNPJNQB4N4bJPiBgq/rkWKMABApX0w4trSkkX5q+l+CL\n"
                         + "CuddGGAsAu6XPari8v49ipbBmHqRLP9+X3ARGWKU2gDvGTBr99/ReUl2YgVjCwy+\n"
                         + "KMrGCN7SNTgRo6StwVaPhh6pUpNTQciDe/kOwUnQFWSM6/lwkOD1Uod45wIBIwKB\n"
@@ -117,17 +122,7 @@ public class TrileadSSHPublicKeyAuthenticatorTest {
                         + "VLWIrDJsTTveLCaBFhNt3cMHA45ysnGiF1GzD+5mdzAdITBP9qvAjIgLQjjlRrH4\n"
                         + "w8eXsXQXjJgyjR0CQHfvhiMPG5pWwmXpsEOFo6GKSvOC/5sNEcnddenuO/2T7WWi\n"
                         + "o1LQh9naeuX8gti0vNR8+KtMEaIcJJeWnk56AVY=\n"
-                        + "-----END RSA PRIVATE KEY-----\n";
-            }
-
-            @CheckForNull
-            public Secret getPassphrase() {
-                return null;
-            }
-
-            @NonNull
-            public List<String> getPrivateKeys() {
-                return Collections.singletonList(getPrivateKey());
+                        + "-----END RSA PRIVATE KEY-----\n");
             }
         };
     }


### PR DESCRIPTION
This method is deprecated, and implementation still need to implement it. We have default methods now, so let's just leverage that to avoid useless boilerplate.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
