### PR TITLE
Use plugin bom version prior to trilead API upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,11 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.426.x</artifactId>
-        <version>3208.vb_21177d4b_cd9</version>
+	<!-- Last 2.426.x BOM version before a trilead api upgrade -->
+	<!-- Trilead API upgrade breaks plugin compatibility tests due to poor handling of optional dependencies -->
+	<!-- Do not change this without checking plugin BOM passes with new version -->
+	<!-- https://github.com/jenkinsci/bom/pull/3404 -->
+        <version>3080.vfa_b_e4a_a_39b_44</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
## Use plugin bom version prior to trilead API upgrade

The plugin compatibility tester mistakenly uses the version of optional plugins that is provided by the pom of the tested plugin rather than using the version of plugin that is listed in the pom file of the plugin bill of materials.

Because of that issue, the 2.426.x plugin bill of materials version needs to remain on an older version in order to not include an optional dependency on a newer version of the trilead API plugin.

[3080.vfa_b_e4a_a_39b_44](https://github.com/jenkinsci/bom/releases/tag/3080.vfa_b_e4a_a_39b_44) is the version immediately before a trilead API plugin upgrade in the BOM.

More details are available in:

* https://github.com/jenkinsci/bom/pull/3404

Additional information is also available in:

* https://github.com/jenkinsci/ssh-credentials-plugin/pull/211

### Testing done

Confirmed that plugin BOM tests pass with:

`LINE=2.440.x PLUGINS=git-server,workflow-basic-steps,git,pipeline-model-definition,docker-workflow,blueocean TEST=InjectedTest bash local-test.sh`

Once an incremental build is available for this pull request, I'll test it with the plugin BOM.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
