### PR TITLE
replace RUN_SCRIPTS with ADMINISTER

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey.java
@@ -443,7 +443,7 @@ public class BasicSSHUserPrivateKey extends BaseSSHUser implements SSHUserPrivat
                 return new DirectEntryPrivateKeySource(privateKeyFile);
             }
 
-            Jenkins.get().checkPermission(Jenkins.RUN_SCRIPTS);
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
             LOGGER.log(Level.INFO, "SECURITY-440: Migrating FileOnMasterPrivateKeySource to DirectEntryPrivateKeySource");
             // read the content of the file and then migrate to Direct
@@ -530,7 +530,7 @@ public class BasicSSHUserPrivateKey extends BaseSSHUser implements SSHUserPrivat
         }
 
         private Object readResolve() {
-            Jenkins.get().checkPermission(Jenkins.RUN_SCRIPTS);
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
             LOGGER.log(Level.INFO, "SECURITY-440: Migrating UsersPrivateKeySource to DirectEntryPrivateKeySource");
             // read the content of the file and then migrate to Direct

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKeyTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKeyTest.java
@@ -98,7 +98,7 @@ public class BasicSSHUserPrivateKeyTest {
                     .withStdin(updateFolder.read())
                     .invokeWithArgs("folder1");
             
-            assertThat(result.stderr(), containsString("user is missing the Overall/RunScripts permission"));
+            assertThat(result.stderr(), containsString("user is missing the Overall/Administer permission"));
             assertThat(result, failedWith(1));
             
             // config file not touched


### PR DESCRIPTION
replace RUN_SCRIPTS with ADMINISTER

RUN SCripts is deprecated and realms don;t grant it on its own without ADMINISTER as it really is ADMINISTER.

Just check ADMINISTER

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
