### PR TITLE
Remove usages of `StringUtils`

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BaseSSHUser.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BaseSSHUser.java
@@ -6,7 +6,6 @@ import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundSetter;
 
 /**
@@ -45,7 +44,7 @@ public class BaseSSHUser extends BaseStandardCredentials implements SSHUser, Sta
      */
     @NonNull
     public String getUsername() {
-        return StringUtils.isEmpty(username) ? System.getProperty("user.name") : username;
+        return username == null || username.isEmpty() ? System.getProperty("user.name") : username;
     }
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey.java
@@ -55,7 +55,6 @@ import jenkins.model.Jenkins;
 import jenkins.security.FIPS140;
 import net.jcip.annotations.GuardedBy;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -194,7 +193,7 @@ public class BasicSSHUserPrivateKey extends BaseSSHUser implements SSHUserPrivat
         if (!FIPS140.useCompliantAlgorithms()) {
             return; // maintain existing behaviour if not in FIPS mode
         }
-        if (StringUtils.isBlank(privateKeySource)) {
+        if (privateKeySource == null || privateKeySource.isBlank()) {
             return;
         }
         try {
@@ -313,7 +312,7 @@ public class BasicSSHUserPrivateKey extends BaseSSHUser implements SSHUserPrivat
         }
 
         public DirectEntryPrivateKeySource(List<String> privateKeys) {
-            this(StringUtils.join(privateKeys, "\f"));
+            this(String.join("\f", privateKeys));
         }
 
         /**
@@ -323,9 +322,9 @@ public class BasicSSHUserPrivateKey extends BaseSSHUser implements SSHUserPrivat
         @Override
         public List<String> getPrivateKeys() {
             String privateKeys = Secret.toString(privateKey);
-            return StringUtils.isBlank(privateKeys)
+            return privateKeys == null || privateKeys.isBlank()
                     ? Collections.emptyList()
-                    : Arrays.asList(StringUtils.split(privateKeys, "\f"));
+                    : Arrays.asList(privateKeys.split("\f"));
         }
 
         /**

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKeyFIPSTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKeyFIPSTest.java
@@ -10,7 +10,6 @@ import hudson.ExtensionList;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -115,9 +114,9 @@ public class BasicSSHUserPrivateKeyFIPSTest {
     private static void checkFormValidation(JenkinsRule r) throws IOException {
         BasicSSHUserPrivateKey.DirectEntryPrivateKeySource.DescriptorImpl descriptor = ExtensionList.lookupSingleton(BasicSSHUserPrivateKey.DirectEntryPrivateKeySource.DescriptorImpl.class);
         FormValidation result = descriptor.doCheckPrivateKey(getKey("rsa2048").getPrivateKey().getPlainText(), "fipsvalidpassword");
-        assertTrue(StringUtils.isBlank(result.getMessage()));
+        assertNull(result.getMessage());
         result = descriptor.doCheckPrivateKey(getKey("rsa1024").getPrivateKey().getPlainText(), "fipsvalidpassword");
-        assertTrue(StringUtils.isNotBlank(result.getMessage()));
+        assertFalse(result.getMessage().isBlank());
     }
 
     private static BasicSSHUserPrivateKey.DirectEntryPrivateKeySource getKey(String file) throws IOException {


### PR DESCRIPTION
No need to depend on a third-party library when the Java Platform would suffice.